### PR TITLE
Fix table column names

### DIFF
--- a/resources/events.hubdb.json
+++ b/resources/events.hubdb.json
@@ -23,12 +23,12 @@
       "width": 206,
       "type": "IMAGE"
     },
+    { "name": "event_capacity", "label": "Event Capacity", "type": "NUMBER" },
     {
-      "name": "space_available",
-      "label": "Event Capacity",
+      "name": "registered_attendee_count",
+      "label": "Registered Attendee Count",
       "type": "NUMBER"
     },
-    { "name": "registered_registered_attendee_count", "label": "Registered Attendee Count", "type": "NUMBER" },
     { "name": "form_guid", "label": "Event Form", "type": "TEXT" }
   ],
   "rows": [
@@ -49,7 +49,7 @@
           "height": 745,
           "type": "image"
         },
-        "event_capacity": 10,
+        "event_capacity": 40,
         "registered_attendee_count": 0,
         "form_guid": "000-000-000"
       }
@@ -71,7 +71,7 @@
           "height": 745,
           "type": "image"
         },
-        "event_capacity": 10,
+        "event_capacity": 40,
         "registered_attendee_count": 0,
         "form_guid": "000-000-000"
       }
@@ -93,7 +93,7 @@
           "height": 745,
           "type": "image"
         },
-        "event_capacity": 10,
+        "event_capacity": 40,
         "registered_attendee_count": 0,
         "form_guid": "000-000-000"
       }


### PR DESCRIPTION
The sample hubdb table reference some incorrect table columns which caused "There are NaN spots left" to display instead of the correct number of remaining spots.

<img width="389" alt="image" src="https://user-images.githubusercontent.com/9009552/78673775-9c4b9e00-78b0-11ea-99d8-3b6981c3ec7e.png">
