### PR TITLE
Fix 'join waitlist' state for at-capacity events' registration forms

### DIFF
--- a/src/components/EventDetails.js
+++ b/src/components/EventDetails.js
@@ -119,7 +119,11 @@ const EventDetails = () => {
           </div>
           <div className="event-details__column event-details__column--sidebar">
             <EventDetailsRegistration
-              isFull={event.values.event_capacity <= 0}
+              isFull={
+                event.values.event_capacity -
+                  event.values.registered_attendee_count <=
+                0
+              }
               isClosed={event.values.start < Date.now()}
             />
           </div>


### PR DESCRIPTION
This didn't make it into the initial commit prior to release. Adds correct `isFull` calculation to the event details registration form.