### PR TITLE
Allow event app to render on any page and make upcoming modules more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,16 @@ Join [#events-app-beta](https://hubspotdev.slack.com/archives/C011GFF8KNZ) in th
    - Last name
    - Email
 
+### Using the upcoming events module
+1. Add the `Upcoming Events` module to any page
+2. In the sidebar, under `Options`, select your events page
+
 ### Setting up membership
 
 _Note: In order to set up membership, your account will need a [connected domain](https://knowledge.hubspot.com/cos-general/connect-a-domain-to-hubspot)_
 
-8. Create a [dynamic list](https://app.hubspot.com/l/contacts/lists) that includes contacts that have filled out any event form
-9. Create a "My Events" page in your portal that:
+1. Create a [dynamic list](https://app.hubspot.com/l/contacts/lists) that includes contacts that have filled out any event form
+2. Create a "My Events" page in your portal that:
    - Has the slug `/my-events/`
    - Uses the `Events app` module in a page template; the page shouldn't be dynamic
    - Under "Control audience access for page", select "Private - Registration required" and select the list you made in the previous step

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Join [#events-app-beta](https://hubspotdev.slack.com/archives/C011GFF8KNZ) in th
 4. Add your [HubSpot API key](https://knowledge.hubspot.com/integrations/how-do-i-get-my-hubspot-api-key) for the portal by running `yarn hs secrets add APIKEY <api-key-goes-here>`. The API key is used by `eventSignup.js` to update the HubDB table
 5. Run `yarn start` which will build the javascript, auto-upload the files to your `defaultPortal`, and watch for changes
 6. Create a page in your portal that:
-    - Has the slug `/events/`
     - Uses the `Events app` module in a page template
     - References the `Events` HubDB table, set up for dynamic pages
 

--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -7,7 +7,7 @@ const AppProvider = props => {
 
   const getEvents = async () => {
     let response = await fetch(
-      `https://api.hubspot.com/cms/v3/hubdb/tables/events/rows?sort=start&portalId=${props.portalId}`,
+      `https://api.hubspot.com/cms/v3/hubdb/tables/events/rows?sort=start&portalId=${APP_CONFIG.portalId}`,
     );
     response = await response.json()
     setState(state => ({ ...state, events: response.results }));

--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -7,7 +7,7 @@ const AppProvider = props => {
 
   const getEvents = async () => {
     let response = await fetch(
-      `https://api.hubspot.com/cms/v3/hubdb/tables/events/rows?sort=start&portalId=${APP_CONFIG.portalId}`,
+      `https://api.hubspot.com/cms/v3/hubdb/tables/events/rows?sort=start&portalId=${props.portalId}`,
     );
     response = await response.json()
     setState(state => ({ ...state, events: response.results }));

--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 const AppContext = React.createContext([{}, () => {}]);
 
 const AppProvider = props => {
-  const [state, setState] = useState({ contact: {}, events: []});
+  const [state, setState] = useState({ contact: {}, events: [], appSlug: props.appSlug});
 
   const getEvents = async () => {
     let response = await fetch(

--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 const AppContext = React.createContext([{}, () => {}]);
 
 const AppProvider = props => {
-  const [state, setState] = useState({ contact: {}, events: [], appSlug: props.appSlug});
+  const [state, setState] = useState({contact: {}, events: []});
 
   const getEvents = async () => {
     let response = await fetch(

--- a/src/UpcomingEvents.js
+++ b/src/UpcomingEvents.js
@@ -23,6 +23,7 @@ function UpcomingEvents({appRoot}) {
   );
 }
 const root = document.getElementById('upcoming-events__module');
+const APP_CONFIG = window[root.dataset.config];
 
 ReactDOM.render(
   <AppProvider portalId={APP_CONFIG.portalId}>

--- a/src/UpcomingEvents.js
+++ b/src/UpcomingEvents.js
@@ -6,7 +6,7 @@ import { AppContext, AppProvider } from './AppContext';
 import EventCard from './components/EventCard';
 import './scss/upcoming-events.scss';
 
-function UpcomingEvents() {
+function UpcomingEvents({appRoot}) {
   const [state] = useContext(AppContext);
   const upcomingEvents = state.events.reverse().slice(0, 3);
 
@@ -14,7 +14,7 @@ function UpcomingEvents() {
     <div className="event-card__wrapper">
       {upcomingEvents.map(function(obj, i) {
         return (
-          <a href={`/${state.appSlug}/${obj.path}`} className="event-card__wrapper--link">
+          <a href={`${appRoot}/${obj.path}`} className="event-card__wrapper--link">
             <EventCard key={i} row={obj} />
           </a>
         );
@@ -24,11 +24,11 @@ function UpcomingEvents() {
 }
 const root = document.getElementById('upcoming-events__module');
 const portalId = Number(root.dataset.portalId);
-const slug = root.dataset.slug;
+const appRoot = root.dataset.appRoot;
 
 ReactDOM.render(
-  <AppProvider portalId={portalId} appSlug={slug}>
-    <UpcomingEvents />
+  <AppProvider portalId={portalId}>
+    <UpcomingEvents appRoot={appRoot} />
   </AppProvider>,
   root,
 );

--- a/src/UpcomingEvents.js
+++ b/src/UpcomingEvents.js
@@ -23,12 +23,10 @@ function UpcomingEvents({appRoot}) {
   );
 }
 const root = document.getElementById('upcoming-events__module');
-const portalId = Number(root.dataset.portalId);
-const appRoot = root.dataset.appRoot;
 
 ReactDOM.render(
-  <AppProvider portalId={portalId}>
-    <UpcomingEvents appRoot={appRoot} />
+  <AppProvider portalId={APP_CONFIG.portalId}>
+    <UpcomingEvents appRoot={APP_CONFIG.appRoot} />
   </AppProvider>,
   root,
 );

--- a/src/UpcomingEvents.js
+++ b/src/UpcomingEvents.js
@@ -22,12 +22,17 @@ function UpcomingEvents({appRoot}) {
     </div>
   );
 }
-const root = document.getElementById('upcoming-events__module');
-const APP_CONFIG = window[root.dataset.config];
 
-ReactDOM.render(
-  <AppProvider portalId={APP_CONFIG.portalId}>
-    <UpcomingEvents appRoot={APP_CONFIG.appRoot} />
-  </AppProvider>,
-  root,
-);
+const root = document.querySelectorAll('.upcoming-events__module');
+
+root.forEach((el) => {
+  const APP_CONFIG = window[el.dataset.config];
+  ReactDOM.render(
+    <AppProvider portalId={APP_CONFIG.portalId}>
+      <UpcomingEvents appRoot={APP_CONFIG.appRoot} />
+    </AppProvider>,
+    el,
+  );
+})
+
+

--- a/src/UpcomingEvents.js
+++ b/src/UpcomingEvents.js
@@ -1,3 +1,4 @@
+import 'regenerator-runtime';
 import React, { useContext } from 'react';
 import ReactDOM from 'react-dom';
 import { AppContext, AppProvider } from './AppContext';
@@ -22,9 +23,10 @@ function UpcomingEvents() {
 }
 const root = document.getElementById('upcoming-events__module');
 const portalId = Number(root.dataset.portalId);
+const slug = root.dataset.slug;
 
 ReactDOM.render(
-  <AppProvider portalId={portalId}>
+  <AppProvider portalId={portalId} appSlug={slug}>
     <UpcomingEvents />
   </AppProvider>,
   root,

--- a/src/UpcomingEvents.js
+++ b/src/UpcomingEvents.js
@@ -13,7 +13,7 @@ function UpcomingEvents() {
     <div className="event-card__wrapper">
       {upcomingEvents.map(function(obj, i) {
         return (
-          <a href={`/events/${obj.path}`} className="event-card__wrapper--link">
+          <a href={`/${state.appSlug}/${obj.path}`} className="event-card__wrapper--link">
             <EventCard key={i} row={obj} />
           </a>
         );

--- a/src/UpcomingEvents.js
+++ b/src/UpcomingEvents.js
@@ -6,7 +6,7 @@ import { AppContext, AppProvider } from './AppContext';
 import EventCard from './components/EventCard';
 import './scss/upcoming-events.scss';
 
-function UpcomingEvents({appRoot}) {
+function UpcomingEvents({ appRoot }) {
   const [state] = useContext(AppContext);
   const upcomingEvents = state.events.reverse().slice(0, 3);
 
@@ -14,7 +14,10 @@ function UpcomingEvents({appRoot}) {
     <div className="event-card__wrapper">
       {upcomingEvents.map(function(obj, i) {
         return (
-          <a href={`${appRoot}/${obj.path}`} className="event-card__wrapper--link">
+          <a
+            href={`${appRoot}/${obj.path}`}
+            className="event-card__wrapper--link"
+          >
             <EventCard key={i} row={obj} />
           </a>
         );
@@ -25,7 +28,7 @@ function UpcomingEvents({appRoot}) {
 
 const root = document.querySelectorAll('.upcoming-events__module');
 
-root.forEach((el) => {
+root.forEach(el => {
   const APP_CONFIG = window[el.dataset.config];
   ReactDOM.render(
     <AppProvider portalId={APP_CONFIG.portalId}>
@@ -33,6 +36,4 @@ root.forEach((el) => {
     </AppProvider>,
     el,
   );
-})
-
-
+});

--- a/src/components/AppHero.js
+++ b/src/components/AppHero.js
@@ -1,10 +1,9 @@
-import React, {useContext} from 'react';
+import React from 'react';
 import left from '../images/left.svg';
-import { Link } from 'react-router-dom';
-import { AppContext } from '../AppContext';
+import { Link, useParams } from 'react-router-dom';
 
 const AppHero = () => {
-  const [state] = useContext(AppContext);
+  const {appRoot} = useParams();
 
   return (
     <header
@@ -13,7 +12,7 @@ const AppHero = () => {
         backgroundImage: `url("{{ get_asset_url('./images/grayscale-mountain-banner.png') }}")`,
       }}
     >
-      <Link to={`/${state.appSlug}`} className="back-banner">
+      <Link to={`/${appRoot}`} className="back-banner">
         <img src={left} className="back-banner__icon" /> Back to Events
       </Link>
     </header>

--- a/src/components/AppHero.js
+++ b/src/components/AppHero.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import left from '../images/left.svg';
-import { Link, useParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 const AppHero = () => {
-  const {appRoot} = useParams();
 
   return (
     <header
@@ -12,7 +11,7 @@ const AppHero = () => {
         backgroundImage: `url("{{ get_asset_url('./images/grayscale-mountain-banner.png') }}")`,
       }}
     >
-      <Link to={`/${appRoot}`} className="back-banner">
+      <Link to={`/${APP_CONFIG.appRoot}`} className="back-banner">
         <img src={left} className="back-banner__icon" /> Back to Events
       </Link>
     </header>

--- a/src/components/AppHero.js
+++ b/src/components/AppHero.js
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, {useContext} from 'react';
 import left from '../images/left.svg';
 import { Link } from 'react-router-dom';
+import { AppContext } from '../AppContext';
 
 const AppHero = () => {
+  const [state] = useContext(AppContext);
+
   return (
     <header
       className="App-hero"
@@ -10,7 +13,7 @@ const AppHero = () => {
         backgroundImage: `url("{{ get_asset_url('./images/grayscale-mountain-banner.png') }}")`,
       }}
     >
-      <Link to="/events" className="back-banner">
+      <Link to={`/${state.appSlug}`} className="back-banner">
         <img src={left} className="back-banner__icon" /> Back to Events
       </Link>
     </header>

--- a/src/components/AppHero.js
+++ b/src/components/AppHero.js
@@ -3,7 +3,6 @@ import left from '../images/left.svg';
 import { Link } from 'react-router-dom';
 
 const AppHero = () => {
-
   return (
     <header
       className="App-hero"

--- a/src/components/AppHero.js
+++ b/src/components/AppHero.js
@@ -10,7 +10,7 @@ const AppHero = () => {
         backgroundImage: `url("{{ get_asset_url('./images/grayscale-mountain-banner.png') }}")`,
       }}
     >
-      <Link to={`/${APP_CONFIG.appRoot}`} className="back-banner">
+      <Link to={`/${window.APP_CONFIG.appRoot}`} className="back-banner">
         <img src={left} className="back-banner__icon" /> Back to Events
       </Link>
     </header>

--- a/src/components/EventCalendar.js
+++ b/src/components/EventCalendar.js
@@ -20,7 +20,7 @@ const EventCalendar = ({ history }) => {
         return (
           dateMatch(day, event.values.start) &&
           event.path &&
-          history.push(`/${APP_CONFIG.appRoot}/${event.path}`)
+          history.push(`/${window.APP_CONFIG.appRoot}/${event.path}`)
         );
       });
     }

--- a/src/components/EventCalendar.js
+++ b/src/components/EventCalendar.js
@@ -3,12 +3,11 @@ import DayPicker from 'react-day-picker';
 import { AppContext } from '../AppContext';
 import dayjs from 'dayjs';
 import isBetween from 'dayjs/plugin/isBetween';
-import { withRouter, useParams } from 'react-router-dom';
+import { withRouter } from 'react-router-dom';
 import './EventCalendar.scss';
 
 const EventCalendar = ({ history }) => {
   const [state] = useContext(AppContext);
-  const {appRoot} = useParams();
   dayjs.extend(isBetween);
 
   function dateMatch(date, start) {
@@ -21,7 +20,7 @@ const EventCalendar = ({ history }) => {
         return (
           dateMatch(day, event.values.start) &&
           event.path &&
-          history.push(`${appRoot}/${event.path}`)
+          history.push(`/${APP_CONFIG.appRoot}/${event.path}`)
         );
       });
     }

--- a/src/components/EventCalendar.js
+++ b/src/components/EventCalendar.js
@@ -20,7 +20,7 @@ const EventCalendar = ({ history }) => {
         return (
           dateMatch(day, event.values.start) &&
           event.path &&
-          history.push(`/events/${event.path}`)
+          history.push(`/${state.appSlug}/${event.path}`)
         );
       });
     }

--- a/src/components/EventCalendar.js
+++ b/src/components/EventCalendar.js
@@ -3,11 +3,12 @@ import DayPicker from 'react-day-picker';
 import { AppContext } from '../AppContext';
 import dayjs from 'dayjs';
 import isBetween from 'dayjs/plugin/isBetween';
-import { withRouter } from 'react-router-dom';
+import { withRouter, useParams } from 'react-router-dom';
 import './EventCalendar.scss';
 
 const EventCalendar = ({ history }) => {
   const [state] = useContext(AppContext);
+  const {appRoot} = useParams();
   dayjs.extend(isBetween);
 
   function dateMatch(date, start) {
@@ -20,7 +21,7 @@ const EventCalendar = ({ history }) => {
         return (
           dateMatch(day, event.values.start) &&
           event.path &&
-          history.push(`/${state.appSlug}/${event.path}`)
+          history.push(`${appRoot}/${event.path}`)
         );
       });
     }

--- a/src/components/EventListings.js
+++ b/src/components/EventListings.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import EventCard from './EventCard';
 import './EventListings.scss';
 
 const EventListings = ({ events, currentSearch }) => {
-  const { appRoot } = useParams();
   let filteredEvents = events;
 
   if (currentSearch) {
@@ -12,7 +11,7 @@ const EventListings = ({ events, currentSearch }) => {
       event.values.name.toLowerCase().includes(currentSearch.toLowerCase()),
     );
   }
-
+console.log(APP_CONFIG.appRoot)
   return (
     <div className="event-listings">
       {currentSearch && filteredEvents.length === 0 ? (
@@ -20,7 +19,7 @@ const EventListings = ({ events, currentSearch }) => {
       ) : (
         filteredEvents.map(function(obj, i) {
           return (
-            <Link to={`/${appRoot}/${obj.path}`} className="event-card__link">
+            <Link to={`${APP_CONFIG.appRoot}/${obj.path}`} className="event-card__link">
               <EventCard key={i} row={obj} />
             </Link>
           );

--- a/src/components/EventListings.js
+++ b/src/components/EventListings.js
@@ -20,7 +20,7 @@ const EventListings = ({ events, currentSearch }) => {
         filteredEvents.map(function(obj, i) {
           return (
             <Link
-              to={`${APP_CONFIG.appRoot}/${obj.path}`}
+              to={`${window.APP_CONFIG.appRoot}/${obj.path}`}
               className="event-card__link"
             >
               <EventCard key={i} row={obj} />

--- a/src/components/EventListings.js
+++ b/src/components/EventListings.js
@@ -1,12 +1,10 @@
-import React, { useContext }  from 'react';
-import { Link } from 'react-router-dom';
+import React from 'react';
+import { Link, useParams } from 'react-router-dom';
 import EventCard from './EventCard';
 import './EventListings.scss';
-import { AppContext } from '../AppContext';
-
 
 const EventListings = ({ events, currentSearch }) => {
-  const [state] = useContext(AppContext);
+  const { appRoot } = useParams();
   let filteredEvents = events;
 
   if (currentSearch) {
@@ -22,7 +20,7 @@ const EventListings = ({ events, currentSearch }) => {
       ) : (
         filteredEvents.map(function(obj, i) {
           return (
-            <Link to={`/${state.appSlug}/${obj.path}`} className="event-card__link">
+            <Link to={`/${appRoot}/${obj.path}`} className="event-card__link">
               <EventCard key={i} row={obj} />
             </Link>
           );

--- a/src/components/EventListings.js
+++ b/src/components/EventListings.js
@@ -11,7 +11,7 @@ const EventListings = ({ events, currentSearch }) => {
       event.values.name.toLowerCase().includes(currentSearch.toLowerCase()),
     );
   }
-console.log(APP_CONFIG.appRoot)
+
   return (
     <div className="event-listings">
       {currentSearch && filteredEvents.length === 0 ? (

--- a/src/components/EventListings.js
+++ b/src/components/EventListings.js
@@ -19,7 +19,10 @@ const EventListings = ({ events, currentSearch }) => {
       ) : (
         filteredEvents.map(function(obj, i) {
           return (
-            <Link to={`${APP_CONFIG.appRoot}/${obj.path}`} className="event-card__link">
+            <Link
+              to={`${APP_CONFIG.appRoot}/${obj.path}`}
+              className="event-card__link"
+            >
               <EventCard key={i} row={obj} />
             </Link>
           );

--- a/src/components/EventListings.js
+++ b/src/components/EventListings.js
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { useContext }  from 'react';
 import { Link } from 'react-router-dom';
 import EventCard from './EventCard';
 import './EventListings.scss';
+import { AppContext } from '../AppContext';
+
 
 const EventListings = ({ events, currentSearch }) => {
+  const [state] = useContext(AppContext);
   let filteredEvents = events;
 
   if (currentSearch) {
@@ -19,7 +22,7 @@ const EventListings = ({ events, currentSearch }) => {
       ) : (
         filteredEvents.map(function(obj, i) {
           return (
-            <Link to={`/events/${obj.path}`} className="event-card__link">
+            <Link to={`/${state.appSlug}/${obj.path}`} className="event-card__link">
               <EventCard key={i} row={obj} />
             </Link>
           );

--- a/src/components/RegisteredEventListings.js
+++ b/src/components/RegisteredEventListings.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useContext } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { AppContext } from '../AppContext';
 import EventCard from './EventCard';
 import LoadingSpinner from './LoadingSpinner';
@@ -8,6 +8,7 @@ function RegisteredEventListings() {
   const [state] = useContext(AppContext);
   const [submissions, setSubmissions] = useState([]);
   const [submissionsLoaded, setSubmissionsLoaded] = useState(false);
+  const {appRoot} = useParams();
 
   const getRegisteredEvents = async () => {
     // This function POSTs in order to pass cookies to the API and recieves a formSubmissions object
@@ -36,7 +37,7 @@ function RegisteredEventListings() {
           {state.events.map(
             (event, i) =>
               submissions.indexOf(event.values.form_guid) != -1 && (
-                <Link to={`/${state.appSlug}/${event.path}`} className="event-card__link">
+                <Link to={`${appRoot}/${event.path}`} className="event-card__link">
                   <EventCard key={i} row={event} />
                 </Link>
               ),

--- a/src/components/RegisteredEventListings.js
+++ b/src/components/RegisteredEventListings.js
@@ -36,7 +36,7 @@ function RegisteredEventListings() {
           {state.events.map(
             (event, i) =>
               submissions.indexOf(event.values.form_guid) != -1 && (
-                <Link to={`/events/${event.path}`} className="event-card__link">
+                <Link to={`/${state.appSlug}/${event.path}`} className="event-card__link">
                   <EventCard key={i} row={event} />
                 </Link>
               ),

--- a/src/components/RegisteredEventListings.js
+++ b/src/components/RegisteredEventListings.js
@@ -36,7 +36,10 @@ function RegisteredEventListings() {
           {state.events.map(
             (event, i) =>
               submissions.indexOf(event.values.form_guid) != -1 && (
-                <Link to={`${APP_CONFIG.appRoot}/${event.path}`} className="event-card__link">
+                <Link
+                  to={`${APP_CONFIG.appRoot}/${event.path}`}
+                  className="event-card__link"
+                >
                   <EventCard key={i} row={event} />
                 </Link>
               ),

--- a/src/components/RegisteredEventListings.js
+++ b/src/components/RegisteredEventListings.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useContext } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { AppContext } from '../AppContext';
 import EventCard from './EventCard';
 import LoadingSpinner from './LoadingSpinner';
@@ -8,7 +8,6 @@ function RegisteredEventListings() {
   const [state] = useContext(AppContext);
   const [submissions, setSubmissions] = useState([]);
   const [submissionsLoaded, setSubmissionsLoaded] = useState(false);
-  const {appRoot} = useParams();
 
   const getRegisteredEvents = async () => {
     // This function POSTs in order to pass cookies to the API and recieves a formSubmissions object
@@ -37,7 +36,7 @@ function RegisteredEventListings() {
           {state.events.map(
             (event, i) =>
               submissions.indexOf(event.values.form_guid) != -1 && (
-                <Link to={`${appRoot}/${event.path}`} className="event-card__link">
+                <Link to={`${APP_CONFIG.appRoot}/${event.path}`} className="event-card__link">
                   <EventCard key={i} row={event} />
                 </Link>
               ),

--- a/src/components/RegisteredEventListings.js
+++ b/src/components/RegisteredEventListings.js
@@ -37,7 +37,7 @@ function RegisteredEventListings() {
             (event, i) =>
               submissions.indexOf(event.values.form_guid) != -1 && (
                 <Link
-                  to={`${APP_CONFIG.appRoot}/${event.path}`}
+                  to={`${window.APP_CONFIG.appRoot}/${event.path}`}
                   className="event-card__link"
                 >
                   <EventCard key={i} row={event} />

--- a/src/index.js
+++ b/src/index.js
@@ -20,14 +20,14 @@ const ScrollToTop = () => {
 
 const root = document.getElementById('root');
 const portalId = Number(root.dataset.portalId);
-const appSlug = root.dataset.slug;
+
 ReactDOM.render(
   <BrowserRouter>
     <ScrollToTop />
-    <AppProvider portalId={portalId} appSlug={appSlug}>
+    <AppProvider portalId={portalId}>
       <Switch>
-        <Route exact path={`/${appSlug}`} component={App} />
-        <Route path={`/${appSlug}/:slug`} component={EventDetailPage} />
+        <Route exact path={`/:appRoot`} component={App} />
+        <Route path={`/:appRoot/:slug`} component={EventDetailPage} />
         <Route exact path="/my-events" component={RegisteredEventsPage} />
         <Route component={App} />
       </Switch>

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,10 @@ ReactDOM.render(
     <AppProvider portalId={APP_CONFIG.portalId}>
       <Switch>
         <Route exact path={`/${APP_CONFIG.appRoot}`} component={App} />
-        <Route path={`/${APP_CONFIG.appRoot}/:slug`} component={EventDetailPage} />
+        <Route
+          path={`/${APP_CONFIG.appRoot}/:slug`}
+          component={EventDetailPage}
+        />
         <Route exact path="/my-events" component={RegisteredEventsPage} />
         <Route component={App} />
       </Switch>

--- a/src/index.js
+++ b/src/index.js
@@ -19,10 +19,11 @@ const ScrollToTop = () => {
 
 const root = document.getElementById('root');
 const portalId = Number(root.dataset.portalId);
+const slug = root.dataset.slug;
 ReactDOM.render(
   <BrowserRouter>
     <ScrollToTop />
-    <AppProvider portalId={portalId}>
+    <AppProvider portalId={portalId} appSlug={slug}>
       <Switch>
         <Route exact path="/events" component={App} />
         <Route path="/events/:slug" component={EventDetailPage} />

--- a/src/index.js
+++ b/src/index.js
@@ -19,15 +19,14 @@ const ScrollToTop = () => {
 };
 
 const root = document.getElementById('root');
-const portalId = Number(root.dataset.portalId);
 
 ReactDOM.render(
   <BrowserRouter>
     <ScrollToTop />
-    <AppProvider portalId={portalId}>
+    <AppProvider>
       <Switch>
-        <Route exact path={`/:appRoot`} component={App} />
-        <Route path={`/:appRoot/:slug`} component={EventDetailPage} />
+        <Route exact path={`/${APP_CONFIG.appRoot}`} component={App} />
+        <Route path={`/${APP_CONFIG.appRoot}/:slug`} component={EventDetailPage} />
         <Route exact path="/my-events" component={RegisteredEventsPage} />
         <Route component={App} />
       </Switch>

--- a/src/index.js
+++ b/src/index.js
@@ -25,8 +25,8 @@ ReactDOM.render(
     <ScrollToTop />
     <AppProvider portalId={portalId} appSlug={slug}>
       <Switch>
-        <Route exact path="/{slug}" component={App} />
-        <Route path="/{slug}/:slug" component={EventDetailPage} />
+        <Route exact path={`/${slug}`} component={App} />
+        <Route path={`/${slug}/:slug`} component={EventDetailPage} />
         <Route exact path="/my-events" component={RegisteredEventsPage} />
         <Route component={App} />
       </Switch>

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ const root = document.getElementById('root');
 ReactDOM.render(
   <BrowserRouter>
     <ScrollToTop />
-    <AppProvider>
+    <AppProvider portalId={APP_CONFIG.portalId}>
       <Switch>
         <Route exact path={`/${APP_CONFIG.appRoot}`} component={App} />
         <Route path={`/${APP_CONFIG.appRoot}/:slug`} component={EventDetailPage} />

--- a/src/index.js
+++ b/src/index.js
@@ -25,8 +25,8 @@ ReactDOM.render(
     <ScrollToTop />
     <AppProvider portalId={portalId} appSlug={slug}>
       <Switch>
-        <Route exact path="/events" component={App} />
-        <Route path="/events/:slug" component={EventDetailPage} />
+        <Route exact path="/{slug}" component={App} />
+        <Route path="/{slug}/:slug" component={EventDetailPage} />
         <Route exact path="/my-events" component={RegisteredEventsPage} />
         <Route component={App} />
       </Switch>

--- a/src/index.js
+++ b/src/index.js
@@ -20,14 +20,14 @@ const ScrollToTop = () => {
 
 const root = document.getElementById('root');
 const portalId = Number(root.dataset.portalId);
-const slug = root.dataset.slug;
+const appSlug = root.dataset.slug;
 ReactDOM.render(
   <BrowserRouter>
     <ScrollToTop />
-    <AppProvider portalId={portalId} appSlug={slug}>
+    <AppProvider portalId={portalId} appSlug={appSlug}>
       <Switch>
-        <Route exact path={`/${slug}`} component={App} />
-        <Route path={`/${slug}/:slug`} component={EventDetailPage} />
+        <Route exact path={`/${appSlug}`} component={App} />
+        <Route path={`/${appSlug}/:slug`} component={EventDetailPage} />
         <Route exact path="/my-events" component={RegisteredEventsPage} />
         <Route component={App} />
       </Switch>

--- a/src/index.js
+++ b/src/index.js
@@ -23,11 +23,11 @@ const root = document.getElementById('root');
 ReactDOM.render(
   <BrowserRouter>
     <ScrollToTop />
-    <AppProvider portalId={APP_CONFIG.portalId}>
+    <AppProvider portalId={window.APP_CONFIG.portalId}>
       <Switch>
-        <Route exact path={`/${APP_CONFIG.appRoot}`} component={App} />
+        <Route exact path={`/${window.APP_CONFIG.appRoot}`} component={App} />
         <Route
-          path={`/${APP_CONFIG.appRoot}/:slug`}
+          path={`/${window.APP_CONFIG.appRoot}/:slug`}
           component={EventDetailPage}
         />
         <Route exact path="/my-events" component={RegisteredEventsPage} />

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -1,19 +1,23 @@
 {{ require_css(get_asset_url('../../event-registration.css')) }}
 {{ require_js(get_asset_url('../../event-registration.js'), 'footer') }}
 
-{% set IMAGES = {
-  'close': get_asset_url('../../images/close.png'),
-  'map': get_asset_url('../../images/map.png'),
-  'city': get_asset_url('../../images/city.jpg'),
+{% set APP_CONFIG = {
+  'appRoot': slug,
+  'portalId': portal_id,
+  'images': {
+    'close': get_asset_url('../../images/close.png'),
+    'map': get_asset_url('../../images/map.png'),
+    'city': get_asset_url('../../images/city.jpg'),
   }
+}
 %}
+{% require_js position="head" %}
+<script>
+  var APP_CONFIG = {{ APP_CONFIG|tojson }};
+</script>
+{% end_require_js %}
 
 <div class="event-registration">
   <noscript>You need to enable JavaScript to run this app.</noscript>
-  <div id="root" data-portal-id="{{ portal_id }}" data-slug="{{ slug }}"></div>
-  {% require_js %}
-  <script>
-    var IMAGES = {{ IMAGES|tojson }};
-  </script>
-  {% end_require_js %}
+  <div id="root"></div>
 </div>

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -7,7 +7,7 @@
   'city': get_asset_url('../../images/city.jpg'),
   }
 %}
-{{ slug }}
+
 <div class="event-registration">
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root" data-portal-id="{{ portal_id }}" data-slug="{{ slug }}"></div>

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -13,7 +13,7 @@
 %}
 {% require_js position="head" %}
 <script>
-  var APP_CONFIG = {{ APP_CONFIG|tojson }};
+  window.APP_CONFIG = {{ APP_CONFIG|tojson }};
 </script>
 {% end_require_js %}
 

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -7,10 +7,10 @@
   'city': get_asset_url('../../images/city.jpg'),
   }
 %}
-
+{{ slug }}
 <div class="event-registration">
   <noscript>You need to enable JavaScript to run this app.</noscript>
-  <div id="root" data-portal-id="{{ portal_id }}"></div>
+  <div id="root" data-portal-id="{{ portal_id }}" data-slug="{{ slug }}"></div>
   {% require_js %}
   <script>
     var IMAGES = {{ IMAGES|tojson }};

--- a/src/modules/upcoming-events.module/fields.json
+++ b/src/modules/upcoming-events.module/fields.json
@@ -1,1 +1,11 @@
-[]
+[
+  {
+    "default": null,
+    "id": "event_page",
+    "label": "Event page",
+    "locked": false,
+    "name": "event_page",
+    "required": true,
+    "type": "page"
+  }
+]

--- a/src/modules/upcoming-events.module/module.html
+++ b/src/modules/upcoming-events.module/module.html
@@ -3,5 +3,5 @@
 
 <div class="upcoming-events">
     <h2>Upcoming Events</h2>
-    <div id="upcoming-events__module" data-portal-id="{{ portal_id }}"></div>
+    <div id="upcoming-events__module" data-portal-id="{{ portal_id }}" data-slug="{{ module.event_page.slug }}"></div>
 </div>

--- a/src/modules/upcoming-events.module/module.html
+++ b/src/modules/upcoming-events.module/module.html
@@ -1,8 +1,20 @@
 {{ require_css(get_asset_url('../../upcoming-events.css')) }}
 {{ require_js(get_asset_url('../../upcoming-events.js'), 'footer') }}
 
+{% set APP_CONFIG = {
+  'appRoot': content_by_id(module.event_page).absoluteUrl,
+  'portalId': portal_id,
+}
+%}
+{% require_js position="head" %}
+<script>
+  var APP_CONFIG = {{ APP_CONFIG|tojson }};
+</script>
+{% end_require_js %}
+
+
 <div class="upcoming-events">
     <h2>Upcoming Events</h2>
-    {% set appRoot = content_by_id(module.event_page).absoluteUrl %}
-    <div id="upcoming-events__module" data-portal-id="{{ portal_id }}" data-app-root="{{ appRoot }}"></div>
+    <div id="upcoming-events__module"></div>
 </div>
+

--- a/src/modules/upcoming-events.module/module.html
+++ b/src/modules/upcoming-events.module/module.html
@@ -15,6 +15,6 @@
 
 <div class="upcoming-events">
     <h2>Upcoming Events</h2>
-    <div id="upcoming-events__module" data-config="APP_CONFIG_{{ name }}"></div>
+    <div class="upcoming-events__module" data-config="APP_CONFIG_{{ name }}"></div>
 </div>
 

--- a/src/modules/upcoming-events.module/module.html
+++ b/src/modules/upcoming-events.module/module.html
@@ -3,6 +3,6 @@
 
 <div class="upcoming-events">
     <h2>Upcoming Events</h2>
-    {% set appSlug = content_by_id(module.event_page).slug %}
-    <div id="upcoming-events__module" data-portal-id="{{ portal_id }}" data-slug="{{ appSlug }}"></div>
+    {% set appRoot = content_by_id(module.event_page).absoluteUrl %}
+    <div id="upcoming-events__module" data-portal-id="{{ portal_id }}" data-app-root="{{ appRoot }}"></div>
 </div>

--- a/src/modules/upcoming-events.module/module.html
+++ b/src/modules/upcoming-events.module/module.html
@@ -8,7 +8,7 @@
 %}
 {% require_js position="head" %}
 <script>
-  var APP_CONFIG_{{ name }} = {{ APP_CONFIG|tojson }};
+  window.APP_CONFIG_{{ name }} = {{ APP_CONFIG|tojson }};
 </script>
 {% end_require_js %}
 

--- a/src/modules/upcoming-events.module/module.html
+++ b/src/modules/upcoming-events.module/module.html
@@ -3,5 +3,6 @@
 
 <div class="upcoming-events">
     <h2>Upcoming Events</h2>
-    <div id="upcoming-events__module" data-portal-id="{{ portal_id }}" data-slug="{{ module.event_page.slug }}"></div>
+    {% set appSlug = content_by_id(module.event_page).slug %}
+    <div id="upcoming-events__module" data-portal-id="{{ portal_id }}" data-slug="{{ appSlug }}"></div>
 </div>

--- a/src/modules/upcoming-events.module/module.html
+++ b/src/modules/upcoming-events.module/module.html
@@ -8,13 +8,13 @@
 %}
 {% require_js position="head" %}
 <script>
-  var APP_CONFIG = {{ APP_CONFIG|tojson }};
+  var APP_CONFIG_{{ name }} = {{ APP_CONFIG|tojson }};
 </script>
 {% end_require_js %}
 
 
 <div class="upcoming-events">
     <h2>Upcoming Events</h2>
-    <div id="upcoming-events__module"></div>
+    <div id="upcoming-events__module" data-config="APP_CONFIG_{{ name }}"></div>
 </div>
 


### PR DESCRIPTION
This PR makes it possible to mount the app at any page slug (instead of just `/events`. The main app module will work on any page. The Upcoming events module now has a field that allows you to select the main events page and you can now add multiple Upcoming event modules to the same page (with their own options).
<img width="359" alt="image" src="https://user-images.githubusercontent.com/9009552/78734668-d780b800-7916-11ea-82cd-c1def440a0bc.png">
