### PR TITLE
Fix margins on event titles

### DIFF
--- a/src/components/EventDetails.scss
+++ b/src/components/EventDetails.scss
@@ -20,7 +20,7 @@
 .event-details__image {
   overflow: hidden;
   max-height: 500px;
-  margin: 30px 0;
+  margin: 0 0 30px 0;
 }
 
 .event-details__image img {

--- a/src/scss/App.scss
+++ b/src/scss/App.scss
@@ -82,7 +82,6 @@
 
 .event-header {
   letter-spacing: 2px;
-  margin-bottom: 0;
 }
 .event-description {
   margin-bottom: 35px;


### PR DESCRIPTION
In sum, there were inconsistent margins between page titles on '/events', '/my-event', and '/my-events' pages. 

Each of these event titles was assigned the class "event-header." I loaded each page and compared the margins for each event title, and I narrowed the problem down to the `margin-bottom` property which had been set to 0. 

I believe that the margin-bottom had been set to 0, because on the '/my-event' page (individual event information), there was too much space between the event title and the event cards beneath it. I investigated the event cards and found that the top margin on the event image was too wide. 

My solution was to remove the margin-bottom property from the event-header class and to remove the top margin from the events image.

cc @levinkeo @gcorne @anthmatic 