### PR TITLE
Add color fields to events app module

### DIFF
--- a/src/modules/events-app.module/fields.json
+++ b/src/modules/events-app.module/fields.json
@@ -8,6 +8,14 @@
     "default" : {}
   },
   {
+    "label" : "Event Card Color",
+    "name" : "event_card_color",
+    "type" : "color",
+    "required" : false,
+    "locked" : false,
+    "default" : {}
+  },
+  {
     "label" : "Font Color",
     "name" : "font_color",
     "type" : "color",

--- a/src/modules/events-app.module/fields.json
+++ b/src/modules/events-app.module/fields.json
@@ -1,58 +1,58 @@
 [
   {
-    "label" : "Background color",
-    "name" : "background_color",
-    "type" : "color",
-    "required" : false,
-    "locked" : false,
-    "default" : {}
+    "label": "Background color",
+    "name": "background_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
   },
   {
-    "label" : "Event card color",
-    "name" : "event_card_color",
-    "type" : "color",
-    "required" : false,
-    "locked" : false,
-    "default" : {}
+    "label": "Event card color",
+    "name": "event_card_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
   },
   {
-    "label" : "Calendar color",
-    "name" : "calendar_color",
-    "type" : "color",
-    "required" : false,
-    "locked" : false,
-    "default" : {}
+    "label": "Calendar color",
+    "name": "calendar_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
   },
   {
-    "label" : "Calendar highlight color",
-    "name" : "calendar_highlight_color",
-    "type" : "color",
-    "required" : false,
-    "locked" : false,
-    "default" : {}
+    "label": "Calendar highlight color",
+    "name": "calendar_highlight_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
   },
   {
-    "label" : "Text color",
-    "name" : "text_color",
-    "type" : "color",
-    "required" : false,
-    "locked" : false,
-    "default" : {}
+    "label": "Text color",
+    "name": "text_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
   },
   {
-    "label" : "Title color",
-    "name" : "title_color",
-    "type" : "color",
-    "required" : false,
-    "locked" : false,
-    "default" : {}
+    "label": "Title color",
+    "name": "title_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
   },
   {
-    "label" : "Event title color",
-    "name" : "event_title_color",
-    "type" : "color",
-    "required" : false,
-    "locked" : false,
-    "default" : {}
+    "label": "Event title color",
+    "name": "event_title_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
   }
 ]

--- a/src/modules/events-app.module/fields.json
+++ b/src/modules/events-app.module/fields.json
@@ -1,1 +1,26 @@
-[]
+[
+  {
+    "label" : "Background Color",
+    "name" : "background_color",
+    "type" : "color",
+    "required" : false,
+    "locked" : false,
+    "default" : {}
+  },
+  {
+    "label" : "Font Color",
+    "name" : "font_color",
+    "type" : "color",
+    "required" : false,
+    "locked" : false,
+    "default" : {}
+  },
+  {
+    "label" : "Day Picker Today Color",
+    "name" : "day_picker_today_color",
+    "type" : "color",
+    "required" : false,
+    "locked" : false,
+    "default" : {}
+  }
+]

--- a/src/modules/events-app.module/fields.json
+++ b/src/modules/events-app.module/fields.json
@@ -16,14 +16,6 @@
     "default" : {}
   },
   {
-    "label" : "Text color",
-    "name" : "text_color",
-    "type" : "color",
-    "required" : false,
-    "locked" : false,
-    "default" : {}
-  },
-  {
     "label" : "Calendar color",
     "name" : "calendar_color",
     "type" : "color",
@@ -34,6 +26,30 @@
   {
     "label" : "Calendar highlight color",
     "name" : "calendar_highlight_color",
+    "type" : "color",
+    "required" : false,
+    "locked" : false,
+    "default" : {}
+  },
+  {
+    "label" : "Text color",
+    "name" : "text_color",
+    "type" : "color",
+    "required" : false,
+    "locked" : false,
+    "default" : {}
+  },
+  {
+    "label" : "Title color",
+    "name" : "title_color",
+    "type" : "color",
+    "required" : false,
+    "locked" : false,
+    "default" : {}
+  },
+  {
+    "label" : "Event title color",
+    "name" : "event_title_color",
     "type" : "color",
     "required" : false,
     "locked" : false,

--- a/src/modules/events-app.module/fields.json
+++ b/src/modules/events-app.module/fields.json
@@ -1,6 +1,6 @@
 [
   {
-    "label" : "Background Color",
+    "label" : "Background color",
     "name" : "background_color",
     "type" : "color",
     "required" : false,
@@ -8,7 +8,7 @@
     "default" : {}
   },
   {
-    "label" : "Event Card Color",
+    "label" : "Event card color",
     "name" : "event_card_color",
     "type" : "color",
     "required" : false,
@@ -16,16 +16,24 @@
     "default" : {}
   },
   {
-    "label" : "Font Color",
-    "name" : "font_color",
+    "label" : "Text color",
+    "name" : "text_color",
     "type" : "color",
     "required" : false,
     "locked" : false,
     "default" : {}
   },
   {
-    "label" : "Day Picker Today Color",
-    "name" : "day_picker_today_color",
+    "label" : "Calendar color",
+    "name" : "calendar_color",
+    "type" : "color",
+    "required" : false,
+    "locked" : false,
+    "default" : {}
+  },
+  {
+    "label" : "Calendar highlight color",
+    "name" : "calendar_highlight_color",
     "type" : "color",
     "required" : false,
     "locked" : false,

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -8,7 +8,26 @@
   }
 %}
 
-<div class="event-registration">
+{%- macro outputColorIfSet(color) -%}
+    {%- if color.color -%}
+      {%- if opacity < 100 -%}
+        rgba({{color.color|convert_rgb}}, {{color.opacity/100}})
+      {%- else -%}
+        {{color.color}}
+      {%- endif -%}
+    {%- else -%}
+      inherit
+    {%- endif -%}
+{%- endmacro -%}
+
+<div class="event-registration"
+     style="background-color:{{outputColorIfSet(module.background_color)}};
+            color:{{outputColorIfSet(module.font_color)}};">
+  <style>
+    div .eventCalendar .DayPicker .DayPicker-wrapper .DayPicker-Day--today {
+      background-color: {{outputColorIfSet(module.day_picker_today_color)}};
+    }
+  </style>
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root" data-portal-id="{{ portal_id }}"></div>
   {% require_js %}

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -10,7 +10,7 @@
 
 {%- macro outputColorIfSet(color) -%}
     {%- if color.color -%}
-      {%- if opacity < 100 -%}
+      {%- if color.opacity < 100 -%}
         rgba({{color.color|convert_rgb}}, {{color.opacity/100}})
       {%- else -%}
         {{color.color}}
@@ -22,16 +22,22 @@
 
 <div class="event-registration"
      style="background-color:{{outputColorIfSet(module.background_color)}};
-            color:{{outputColorIfSet(module.font_color)}};">
-  <style>
-    .event-card {
-      background-color: {{outputColorIfSet(module.event_card_color)}};
-    }
+            color:{{outputColorIfSet(module.text_color)}};">
+  {% require_css %}
+    <style>
+      .event-card {
+        background-color: {{outputColorIfSet(module.event_card_color)}};
+      }
 
-    div .eventCalendar .DayPicker .DayPicker-wrapper .DayPicker-Day--today {
-      background-color: {{outputColorIfSet(module.day_picker_today_color)}};
-    }
-  </style>
+      div .eventCalendar .DayPicker .DayPicker-wrapper {
+        background-color: {{outputColorIfSet(module.calendar_color)}};
+      }
+
+      div .eventCalendar .DayPicker .DayPicker-wrapper .DayPicker-Day--today {
+        background-color: {{outputColorIfSet(module.calendar_highlight_color)}};
+      }
+    </style>
+  {% end_require_css %}
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root" data-portal-id="{{ portal_id }}"></div>
   {% require_js %}

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -21,23 +21,23 @@
             color:{{outputColorIfSet(module.text_color)}};">
   {% require_css %}
     <style>
-      .event-header {
+      #hs_cos_wrapper_{{ name }} .event-header {
         color: {{outputColorIfSet(module.title_color)}};
       }
 
-      .event-card__title {
+      #hs_cos_wrapper_{{ name }} .event-card__title {
         color: {{outputColorIfSet(module.event_title_color)}};
       }
 
-      .event-card {
+      #hs_cos_wrapper_{{ name }} .event-card {
         background-color: {{outputColorIfSet(module.event_card_color)}};
       }
 
-      div .eventCalendar .DayPicker .DayPicker-wrapper {
+      #hs_cos_wrapper_{{ name }} div .eventCalendar .DayPicker .DayPicker-wrapper {
         background-color: {{outputColorIfSet(module.calendar_color)}};
       }
 
-      div .eventCalendar .DayPicker .DayPicker-wrapper .DayPicker-Day--today {
+      #hs_cos_wrapper_{{ name }} div .eventCalendar .DayPicker .DayPicker-wrapper .DayPicker-Day--today {
         background-color: {{outputColorIfSet(module.calendar_highlight_color)}};
       }
     </style>

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -9,15 +9,11 @@
 %}
 
 {%- macro outputColorIfSet(color) -%}
-    {%- if color.color -%}
-      {%- if color.opacity < 100 -%}
-        rgba({{color.color|convert_rgb}}, {{color.opacity/100}})
-      {%- else -%}
-        {{color.color}}
-      {%- endif -%}
-    {%- else -%}
-      inherit
-    {%- endif -%}
+  {%- if color.color -%}
+    rgba({{color.color|convert_rgb}}, {{color.opacity/100}})
+  {%- else -%}
+    inherit
+  {%- endif -%}
 {%- endmacro -%}
 
 <div class="event-registration"
@@ -25,6 +21,14 @@
             color:{{outputColorIfSet(module.text_color)}};">
   {% require_css %}
     <style>
+      .event-header {
+        color: {{outputColorIfSet(module.title_color)}};
+      }
+
+      .event-card__title {
+        color: {{outputColorIfSet(module.event_title_color)}};
+      }
+
       .event-card {
         background-color: {{outputColorIfSet(module.event_card_color)}};
       }

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -24,6 +24,10 @@
      style="background-color:{{outputColorIfSet(module.background_color)}};
             color:{{outputColorIfSet(module.font_color)}};">
   <style>
+    .event-card {
+      background-color: {{outputColorIfSet(module.event_card_color)}};
+    }
+
     div .eventCalendar .DayPicker .DayPicker-wrapper .DayPicker-Day--today {
       background-color: {{outputColorIfSet(module.day_picker_today_color)}};
     }


### PR DESCRIPTION
Fixes #7.

Preview: https://akemmerle-7428138.hs-sites.com/events

I've added four color fields to the Events app module: one to control the background color of the module, one to control the event card background color, one to control the font color, and one to control the calendar's highlight color for the current date. 

If anyone has suggestions for more color fields, I'm all ears. I'm planning to continue working on this tomorrow and perhaps into next week. 

Also, if someone could look over the `module.html` file and review how I implemented the color changes, I'd really appreciate it. 

cc @levinkeo @gcorne @anthmatic 
