### PR TITLE
Add color fields to the upcoming events module

### DIFF
--- a/src/modules/upcoming-events.module/fields.json
+++ b/src/modules/upcoming-events.module/fields.json
@@ -1,1 +1,42 @@
-[]
+[
+  {
+    "label" : "Background color",
+    "name" : "background_color",
+    "type" : "color",
+    "required" : false,
+    "locked" : false,
+    "default" : {}
+  },
+  {
+    "label" : "Event card color",
+    "name" : "event_card_color",
+    "type" : "color",
+    "required" : false,
+    "locked" : false,
+    "default" : {}
+  },
+  {
+    "label" : "Text color",
+    "name" : "text_color",
+    "type" : "color",
+    "required" : false,
+    "locked" : false,
+    "default" : {}
+  },
+  {
+    "label" : "Title color",
+    "name" : "title_color",
+    "type" : "color",
+    "required" : false,
+    "locked" : false,
+    "default" : {}
+  },
+  {
+    "label" : "Event title color",
+    "name" : "event_title_color",
+    "type" : "color",
+    "required" : false,
+    "locked" : false,
+    "default" : {}
+  }
+]

--- a/src/modules/upcoming-events.module/module.html
+++ b/src/modules/upcoming-events.module/module.html
@@ -1,34 +1,30 @@
-{{ require_css(get_asset_url('../../upcoming-events.css')) }}
-{{ require_js(get_asset_url('../../upcoming-events.js'), 'footer') }}
+{{ require_css(get_asset_url('../../upcoming-events.css')) }} {{
+require_js(get_asset_url('../../upcoming-events.js'), 'footer') }} {%- macro
+outputColorIfSet(color) -%} {%- if color.color -%}
+rgba({{color.color|convert_rgb}}, {{color.opacity/100}}) {%- else -%} inherit
+{%- endif -%} {%- endmacro -%}
 
-{%- macro outputColorIfSet(color) -%}
-  {%- if color.color -%}
-    rgba({{color.color|convert_rgb}}, {{color.opacity/100}})
-  {%- else -%}
-    inherit
-  {%- endif -%}
-{%- endmacro -%}
+<div
+  class="upcoming-events"
+  style="background-color:{{outputColorIfSet(module.background_color)}};
+            color:{{outputColorIfSet(module.text_color)}};"
+>
+  {% require_css %}
+  <style>
 
-<div class="upcoming-events"
-     style="background-color:{{outputColorIfSet(module.background_color)}};
-            color:{{outputColorIfSet(module.text_color)}};">
-     {% require_css %}
-       <style>
+    #hs_cos_wrapper_{{ name }} .event-card {
+      background-color: {{outputColorIfSet(module.event_card_color)}};
+    }
 
-         .upcoming-events .event-card {
-           background-color: {{outputColorIfSet(module.event_card_color)}};
-         }
+    #hs_cos_wrapper_{{ name }} .event-card__title {
+      color: {{outputColorIfSet(module.event_title_color)}};
+    }
 
-         .upcoming-events .event-card__title {
-           color: {{outputColorIfSet(module.event_title_color)}};
-         }
-
-         .upcoming-events .event-header {
-           color: {{outputColorIfSet(module.title_color)}};
-         }
-
-       </style>
-     {% end_require_css %}
-    <h2 class="event-header">Upcoming Events</h2>
-    <div id="upcoming-events__module" data-portal-id="{{ portal_id }}"></div>
+    #hs_cos_wrapper_{{ name }} .event-header {
+      color: {{outputColorIfSet(module.title_color)}};
+    }
+  </style>
+  {% end_require_css %}
+  <h2 class="event-header">Upcoming Events</h2>
+  <div id="upcoming-events__module" data-portal-id="{{ portal_id }}"></div>
 </div>

--- a/src/modules/upcoming-events.module/module.html
+++ b/src/modules/upcoming-events.module/module.html
@@ -1,7 +1,34 @@
 {{ require_css(get_asset_url('../../upcoming-events.css')) }}
 {{ require_js(get_asset_url('../../upcoming-events.js'), 'footer') }}
 
-<div class="upcoming-events">
-    <h2>Upcoming Events</h2>
+{%- macro outputColorIfSet(color) -%}
+  {%- if color.color -%}
+    rgba({{color.color|convert_rgb}}, {{color.opacity/100}})
+  {%- else -%}
+    inherit
+  {%- endif -%}
+{%- endmacro -%}
+
+<div class="upcoming-events"
+     style="background-color:{{outputColorIfSet(module.background_color)}};
+            color:{{outputColorIfSet(module.text_color)}};">
+     {% require_css %}
+       <style>
+
+         .upcoming-events .event-card {
+           background-color: {{outputColorIfSet(module.event_card_color)}};
+         }
+
+         .upcoming-events .event-card__title {
+           color: {{outputColorIfSet(module.event_title_color)}};
+         }
+
+         .upcoming-events .event-header {
+           color: {{outputColorIfSet(module.title_color)}};
+         }
+
+       </style>
+     {% end_require_css %}
+    <h2 class="event-header">Upcoming Events</h2>
     <div id="upcoming-events__module" data-portal-id="{{ portal_id }}"></div>
 </div>

--- a/src/scss/upcoming-events.scss
+++ b/src/scss/upcoming-events.scss
@@ -10,7 +10,7 @@
     width: 100%;
     max-width: 1400px;
     margin: 0 auto;
-    padding: 40px 40px 0 0;
+    padding: 40px 40px 0 40px;
     text-align: left;
   }
   @media screen and (max-width: 1000px) {


### PR DESCRIPTION
Fixes #17 

I've added five color fields to control:
-the module's background color
-the event cards' background color
-the text color
-the module's title color 
-the event cards' title color 

Per @levinkeo's suggestion here (https://github.com/HubSpot/cms-event-registration/pull/15#discussion_r407559486), I've scoped the CSS, but please let me know if I need to be more specific :) 

If anyone has any suggestions about adding/subtracting color fields or streamlining the code, I'm all ears 

cc @gcorne @levinkeo @anthmatic 

