### PR TITLE
Only create hubdb table if it doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Join [#events-app-beta](https://hubspotdev.slack.com/archives/C011GFF8KNZ) in th
 0. Make sure that you're set up for [local development](https://designers.hubspot.com/tutorials/getting-started) with the [HubSpot CMS CLI](https://designers.hubspot.com/docs/developer-reference/local-development-cms-cli).
 1. Clone this repo to your machine
 2. Install dependencies by running `yarn install`
-3. Run `yarn create-table` to create the HubDB table where you will manage your events
+3. Run `yarn create-table --portal <portalId>` to create the HubDB table where you will manage your events
 4. Add your [HubSpot API key](https://knowledge.hubspot.com/integrations/how-do-i-get-my-hubspot-api-key) for the portal by running `yarn hs secrets add APIKEY <api-key-goes-here>`. The API key is used by `eventSignup.js` to update the HubDB table
 5. Run `yarn start` which will build the javascript, auto-upload the files to your `defaultPortal`, and watch for changes
 6. Create a page in your portal that:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "deploy": "hs upload dist event-registration",
     "lint": "eslint src && prettier --check 'src/**/*.js' 'src/**/*.json'",
     "prettier:write": "prettier --write 'src/**/*.js' 'src/**/*.json'",
-    "create-table": "hs hubdb create ./resources/events.hubdb.json"
+    "create-table": "node ./scripts/createHubDB.js create --table_path ./resources/events.hubdb.json"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@babel/preset-env": "^7.6.2",
     "@babel/preset-react": "^7.0.0",
     "@hubspot/cms-cli": "^1.0.4",
+    "@hubspot/cms-lib": "^1.1.1-beta.0",
     "@hubspot/webpack-cms-plugins": "^1.0.0",
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.6",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@babel/preset-env": "^7.6.2",
     "@babel/preset-react": "^7.0.0",
     "@hubspot/cms-cli": "^1.0.4",
-    "@hubspot/cms-lib": "^1.1.1-beta.0",
     "@hubspot/webpack-cms-plugins": "^1.0.0",
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.6",
@@ -44,6 +43,7 @@
     "yargs": "^14.2.0"
   },
   "dependencies": {
+    "@hubspot/cms-lib": "^1.1.1-beta.0",
     "core-js": "^3.2.1",
     "dayjs": "^1.8.16",
     "js-cookie": "^2.2.1",

--- a/scripts/createHubDb.js
+++ b/scripts/createHubDb.js
@@ -1,9 +1,7 @@
 const fs = require('fs-extra');
 const { getPortalId } = require('@hubspot/cms-lib');
 const hubdb = require('@hubspot/cms-lib/api/hubdb');
-const {
-  createHubDbTable,
-} = require('@hubspot/cms-lib/hubdb');
+const { createHubDbTable } = require('@hubspot/cms-lib/hubdb');
 const argv = require('yargs');
 
 const fetchTables = async portal => {
@@ -13,7 +11,7 @@ const fetchTables = async portal => {
   } catch (e) {
     console.log(
       `There was an error fetching tables from  ${portal}`,
-      e.message
+      e.message,
     );
     return;
   }
@@ -25,7 +23,8 @@ const getTableIdByName = async (tableName, portalId) => {
     const table = tables.find(tab => {
       return tab.name === tableName;
     });
-    return table.id;
+
+    return table;
   } catch (e) {
     console.log(e.message);
   }
@@ -33,24 +32,18 @@ const getTableIdByName = async (tableName, portalId) => {
 
 const createTable = async (portal, src) => {
   const portalId = getPortalId(portal);
-
-  await createHubDbTable(portalId, src);
-}
-
-const createTableIfNone = async (portalId, src) => {
   const { name } = fs.readJsonSync(src);
 
-  const existingTable = await getTableIdByName(name, portalId);
+  const fetchExistingTable = await getTableIdByName(name, portalId);
 
-  if (existingTable) {
-    console.log('Table already exists in portal')
+  if (fetchExistingTable) {
+    console.log('Table already exists in portal');
     return;
   } else {
-    const newTable = await createTable(portalId, src);
-    console.log(`Table with id X was created`)
+    const { tableId } = await createHubDbTable(portalId, src);
+    console.log(`Table with id ${tableId} was created`);
   }
-}
-
+};
 
 argv
   .command(
@@ -58,8 +51,8 @@ argv
     'Create HubDb table in portal',
     () => {},
     argv => {
-      createTableIfNone(argv.portal, argv.table_path);
-    }
+      createTable(argv.portal, argv.table_path);
+    },
   )
   .help()
   .options({

--- a/scripts/createHubDb.js
+++ b/scripts/createHubDb.js
@@ -1,0 +1,72 @@
+const fs = require('fs-extra');
+const { getPortalId } = require('@hubspot/cms-lib');
+const hubdb = require('@hubspot/cms-lib/api/hubdb');
+const {
+  createHubDbTable,
+} = require('@hubspot/cms-lib/hubdb');
+const argv = require('yargs');
+
+const fetchTables = async portal => {
+  try {
+    const response = await hubdb.fetchTables(portal);
+    return response.objects;
+  } catch (e) {
+    console.log(
+      `There was an error fetching tables from  ${portal}`,
+      e.message
+    );
+    return;
+  }
+};
+
+const getTableIdByName = async (tableName, portalId) => {
+  try {
+    const tables = await fetchTables(portalId);
+    const table = tables.find(tab => {
+      return tab.name === tableName;
+    });
+    return table.id;
+  } catch (e) {
+    console.log(e.message);
+  }
+};
+
+const createTable = async (portal, src) => {
+  const portalId = getPortalId(portal);
+
+  await createHubDbTable(portalId, src);
+}
+
+const createTableIfNone = async (portalId, src) => {
+  const { name } = fs.readJsonSync(src);
+
+  const existingTable = await getTableIdByName(name, portalId);
+
+  if (existingTable) {
+    console.log('Table already exists in portal')
+    return;
+  } else {
+    const newTable = await createTable(portalId, src);
+    console.log(`Table with id X was created`)
+  }
+}
+
+
+argv
+  .command(
+    'create',
+    'Create HubDb table in portal',
+    () => {},
+    argv => {
+      createTableIfNone(argv.portal, argv.table_path);
+    }
+  )
+  .help()
+  .options({
+    table_path: {
+      demandOption: true,
+    },
+    portal: {
+      demandOption: true,
+    },
+  }).argv;

--- a/yarn.lock
+++ b/yarn.lock
@@ -876,7 +876,7 @@
 
 "@hubspot/cms-lib@^1.1.1-beta.0":
   version "1.1.1-beta.0"
-  resolved "https://npm.hubteam.com/npm-nexus/repository/npm-all/@hubspot/cms-lib/-/cms-lib-1.1.1-beta.0.tgz#c35cb937ce812a6133b869f3c6e54a3031a2b45b"
+  resolved "https://registry.yarnpkg.com/@hubspot/cms-lib/-/cms-lib-1.1.1-beta.0.tgz#c35cb937ce812a6133b869f3c6e54a3031a2b45b"
   integrity sha512-CKg4/5YOUgpL/ES2K6i+cU4jgzVJiG1PmTUMIkqCRBzYMbkt4UTB8jAYdwC9lp02yvn+I1NlyKjE2K1PN6OdbA==
   dependencies:
     chalk "^2.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -874,6 +874,27 @@
     request-promise-native "^1.0.7"
     unixify "1.0.0"
 
+"@hubspot/cms-lib@^1.1.1-beta.0":
+  version "1.1.1-beta.0"
+  resolved "https://npm.hubteam.com/npm-nexus/repository/npm-all/@hubspot/cms-lib/-/cms-lib-1.1.1-beta.0.tgz#c35cb937ce812a6133b869f3c6e54a3031a2b45b"
+  integrity sha512-CKg4/5YOUgpL/ES2K6i+cU4jgzVJiG1PmTUMIkqCRBzYMbkt4UTB8jAYdwC9lp02yvn+I1NlyKjE2K1PN6OdbA==
+  dependencies:
+    chalk "^2.4.2"
+    chokidar "^3.0.1"
+    content-disposition "^0.5.3"
+    debounce "^1.2.0"
+    extract-zip "^1.6.7"
+    findup-sync "^3.0.0"
+    fs-extra "^8.1.0"
+    ignore "^5.1.4"
+    js-yaml "^3.12.2"
+    moment "^2.24.0"
+    p-queue "^6.0.2"
+    prettier "^1.19.1"
+    request "^2.87.0"
+    request-promise-native "^1.0.7"
+    unixify "1.0.0"
+
 "@hubspot/webpack-cms-plugins@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@hubspot/webpack-cms-plugins/-/webpack-cms-plugins-1.1.0.tgz#20a23205a697553bc493d43d8b37cf258de8ad92"


### PR DESCRIPTION
Instead of using the CMS CLI, this uses CMS-LIB to check if a table exists before creating it, which will prevent issues where multiple tables with the same name get created in a portal.

Fixes #10 