### PR TITLE
Reverts #23 and adds color fields to Upcoming Events module again

### DIFF
--- a/src/modules/upcoming-events.module/fields.json
+++ b/src/modules/upcoming-events.module/fields.json
@@ -1,42 +1,42 @@
 [
   {
-    "label" : "Background color",
-    "name" : "background_color",
-    "type" : "color",
-    "required" : false,
-    "locked" : false,
-    "default" : {}
+    "label": "Background color",
+    "name": "background_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
   },
   {
-    "label" : "Event card color",
-    "name" : "event_card_color",
-    "type" : "color",
-    "required" : false,
-    "locked" : false,
-    "default" : {}
+    "label": "Event card color",
+    "name": "event_card_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
   },
   {
-    "label" : "Text color",
-    "name" : "text_color",
-    "type" : "color",
-    "required" : false,
-    "locked" : false,
-    "default" : {}
+    "label": "Text color",
+    "name": "text_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
   },
   {
-    "label" : "Title color",
-    "name" : "title_color",
-    "type" : "color",
-    "required" : false,
-    "locked" : false,
-    "default" : {}
+    "label": "Title color",
+    "name": "title_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
   },
   {
-    "label" : "Event title color",
-    "name" : "event_title_color",
-    "type" : "color",
-    "required" : false,
-    "locked" : false,
-    "default" : {}
+    "label": "Event title color",
+    "name": "event_title_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
   }
 ]

--- a/src/modules/upcoming-events.module/fields.json
+++ b/src/modules/upcoming-events.module/fields.json
@@ -1,1 +1,42 @@
-[]
+[
+  {
+    "label" : "Background color",
+    "name" : "background_color",
+    "type" : "color",
+    "required" : false,
+    "locked" : false,
+    "default" : {}
+  },
+  {
+    "label" : "Event card color",
+    "name" : "event_card_color",
+    "type" : "color",
+    "required" : false,
+    "locked" : false,
+    "default" : {}
+  },
+  {
+    "label" : "Text color",
+    "name" : "text_color",
+    "type" : "color",
+    "required" : false,
+    "locked" : false,
+    "default" : {}
+  },
+  {
+    "label" : "Title color",
+    "name" : "title_color",
+    "type" : "color",
+    "required" : false,
+    "locked" : false,
+    "default" : {}
+  },
+  {
+    "label" : "Event title color",
+    "name" : "event_title_color",
+    "type" : "color",
+    "required" : false,
+    "locked" : false,
+    "default" : {}
+  }
+]

--- a/src/modules/upcoming-events.module/module.html
+++ b/src/modules/upcoming-events.module/module.html
@@ -1,7 +1,30 @@
-{{ require_css(get_asset_url('../../upcoming-events.css')) }}
-{{ require_js(get_asset_url('../../upcoming-events.js'), 'footer') }}
+{{ require_css(get_asset_url('../../upcoming-events.css')) }} {{
+require_js(get_asset_url('../../upcoming-events.js'), 'footer') }} {%- macro
+outputColorIfSet(color) -%} {%- if color.color -%}
+rgba({{color.color|convert_rgb}}, {{color.opacity/100}}) {%- else -%} inherit
+{%- endif -%} {%- endmacro -%}
 
-<div class="upcoming-events">
-    <h2>Upcoming Events</h2>
-    <div id="upcoming-events__module" data-portal-id="{{ portal_id }}"></div>
+<div
+  class="upcoming-events"
+  style="background-color:{{outputColorIfSet(module.background_color)}};
+            color:{{outputColorIfSet(module.text_color)}};"
+>
+  {% require_css %}
+  <style>
+
+    #hs_cos_wrapper_{{ name }} .event-card {
+      background-color: {{outputColorIfSet(module.event_card_color)}};
+    }
+
+    #hs_cos_wrapper_{{ name }} .event-card__title {
+      color: {{outputColorIfSet(module.event_title_color)}};
+    }
+
+    #hs_cos_wrapper_{{ name }} .event-header {
+      color: {{outputColorIfSet(module.title_color)}};
+    }
+  </style>
+  {% end_require_css %}
+  <h2 class="event-header">Upcoming Events</h2>
+  <div id="upcoming-events__module" data-portal-id="{{ portal_id }}"></div>
 </div>

--- a/src/modules/upcoming-events.module/module.html
+++ b/src/modules/upcoming-events.module/module.html
@@ -1,14 +1,17 @@
-{{ require_css(get_asset_url('../../upcoming-events.css')) }} {{
-require_js(get_asset_url('../../upcoming-events.js'), 'footer') }} {%- macro
-outputColorIfSet(color) -%} {%- if color.color -%}
-rgba({{color.color|convert_rgb}}, {{color.opacity/100}}) {%- else -%} inherit
-{%- endif -%} {%- endmacro -%}
+{{ require_css(get_asset_url('../../upcoming-events.css')) }}
+{{ require_js(get_asset_url('../../upcoming-events.js'), 'footer') }}
 
-<div
-  class="upcoming-events"
-  style="background-color:{{outputColorIfSet(module.background_color)}};
-            color:{{outputColorIfSet(module.text_color)}};"
->
+{%- macro outputColorIfSet(color) -%}
+  {%- if color.color -%}
+    rgba({{color.color|convert_rgb}}, {{color.opacity/100}})
+  {%- else -%}
+    inherit
+  {%- endif -%}
+{%- endmacro -%}
+
+<div class="upcoming-events"
+     style="background-color:{{outputColorIfSet(module.background_color)}};
+            color:{{outputColorIfSet(module.text_color)}};">
   {% require_css %}
   <style>
 
@@ -23,6 +26,7 @@ rgba({{color.color|convert_rgb}}, {{color.opacity/100}}) {%- else -%} inherit
     #hs_cos_wrapper_{{ name }} .event-header {
       color: {{outputColorIfSet(module.title_color)}};
     }
+    
   </style>
   {% end_require_css %}
   <h2 class="event-header">Upcoming Events</h2>

--- a/src/scss/upcoming-events.scss
+++ b/src/scss/upcoming-events.scss
@@ -10,7 +10,7 @@
     width: 100%;
     max-width: 1400px;
     margin: 0 auto;
-    padding: 40px 40px 0 0;
+    padding: 40px 40px 0 40px;
     text-align: left;
   }
   @media screen and (max-width: 1000px) {


### PR DESCRIPTION
I reverted #19 because it was failing the ESLint build checks. I've now edited the Upcoming Events module's `fields.json` and `module.html` to comply with our style guides. 