### PR TITLE
Add color fields to events app module again (Revert the revert)

### DIFF
--- a/src/modules/events-app.module/fields.json
+++ b/src/modules/events-app.module/fields.json
@@ -1,1 +1,58 @@
-[]
+[
+  {
+    "label": "Background color",
+    "name": "background_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
+  },
+  {
+    "label": "Event card color",
+    "name": "event_card_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
+  },
+  {
+    "label": "Calendar color",
+    "name": "calendar_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
+  },
+  {
+    "label": "Calendar highlight color",
+    "name": "calendar_highlight_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
+  },
+  {
+    "label": "Text color",
+    "name": "text_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
+  },
+  {
+    "label": "Title color",
+    "name": "title_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
+  },
+  {
+    "label": "Event title color",
+    "name": "event_title_color",
+    "type": "color",
+    "required": false,
+    "locked": false,
+    "default": {}
+  }
+]

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -8,7 +8,40 @@
   }
 %}
 
-<div class="event-registration">
+{%- macro outputColorIfSet(color) -%}
+  {%- if color.color -%}
+    rgba({{color.color|convert_rgb}}, {{color.opacity/100}})
+  {%- else -%}
+    inherit
+  {%- endif -%}
+{%- endmacro -%}
+
+<div class="event-registration"
+     style="background-color:{{outputColorIfSet(module.background_color)}};
+            color:{{outputColorIfSet(module.text_color)}};">
+  {% require_css %}
+    <style>
+      #hs_cos_wrapper_{{ name }} .event-header {
+        color: {{outputColorIfSet(module.title_color)}};
+      }
+
+      #hs_cos_wrapper_{{ name }} .event-card__title {
+        color: {{outputColorIfSet(module.event_title_color)}};
+      }
+
+      #hs_cos_wrapper_{{ name }} .event-card {
+        background-color: {{outputColorIfSet(module.event_card_color)}};
+      }
+
+      #hs_cos_wrapper_{{ name }} div .eventCalendar .DayPicker .DayPicker-wrapper {
+        background-color: {{outputColorIfSet(module.calendar_color)}};
+      }
+
+      #hs_cos_wrapper_{{ name }} div .eventCalendar .DayPicker .DayPicker-wrapper .DayPicker-Day--today {
+        background-color: {{outputColorIfSet(module.calendar_highlight_color)}};
+      }
+    </style>
+  {% end_require_css %}
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root" data-portal-id="{{ portal_id }}"></div>
   {% require_js %}

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -4,43 +4,42 @@
 {% set IMAGES = {
   'close': get_asset_url('../../images/close.png'),
   'map': get_asset_url('../../images/map.png'),
-  'city': get_asset_url('../../images/city.jpg'),
-  }
-%}
+  'city': get_asset_url('../../images/city.jpg'), } %}
 
 {%- macro outputColorIfSet(color) -%}
   {%- if color.color -%}
     rgba({{color.color|convert_rgb}}, {{color.opacity/100}})
-  {%- else -%}
-    inherit
   {%- endif -%}
 {%- endmacro -%}
 
-<div class="event-registration"
-     style="background-color:{{outputColorIfSet(module.background_color)}};
-            color:{{outputColorIfSet(module.text_color)}};">
+<div class="event-registration">
   {% require_css %}
-    <style>
-      #hs_cos_wrapper_{{ name }} .event-header {
-        color: {{outputColorIfSet(module.title_color)}};
-      }
+  <style>
+    #hs_cos_wrapper_{{ name }} .event-registration {
+      background-color:{{outputColorIfSet(module.background_color)}};
+      color:{{outputColorIfSet(module.text_color)}};
+    }
 
-      #hs_cos_wrapper_{{ name }} .event-card__title {
-        color: {{outputColorIfSet(module.event_title_color)}};
-      }
+    #hs_cos_wrapper_{{ name }} .event-header {
+      color: {{outputColorIfSet(module.title_color)}};
+    }
 
-      #hs_cos_wrapper_{{ name }} .event-card {
-        background-color: {{outputColorIfSet(module.event_card_color)}};
-      }
+    #hs_cos_wrapper_{{ name }} .event-card__title {
+      color: {{outputColorIfSet(module.event_title_color)}};
+    }
 
-      #hs_cos_wrapper_{{ name }} div .eventCalendar .DayPicker .DayPicker-wrapper {
-        background-color: {{outputColorIfSet(module.calendar_color)}};
-      }
+    #hs_cos_wrapper_{{ name }} .event-card {
+      background-color: {{outputColorIfSet(module.event_card_color)}};
+    }
 
-      #hs_cos_wrapper_{{ name }} div .eventCalendar .DayPicker .DayPicker-wrapper .DayPicker-Day--today {
-        background-color: {{outputColorIfSet(module.calendar_highlight_color)}};
-      }
-    </style>
+    #hs_cos_wrapper_{{ name }} div .eventCalendar .DayPicker .DayPicker-wrapper {
+      background-color: {{outputColorIfSet(module.calendar_color)}};
+    }
+
+    #hs_cos_wrapper_{{ name }} div .eventCalendar .DayPicker .DayPicker-wrapper .DayPicker-Day--today {
+      background-color: {{outputColorIfSet(module.calendar_highlight_color)}};
+    }
+  </style>
   {% end_require_css %}
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root" data-portal-id="{{ portal_id }}"></div>

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -6,39 +6,24 @@
   'map': get_asset_url('../../images/map.png'),
   'city': get_asset_url('../../images/city.jpg'), } %}
 
-{%- macro outputColorIfSet(property, color) -%}
+{%- macro outputColorIfSet(property, color, css_selector) -%}
   {%- if color.color -%}
-    {{property}}: rgba({{color.color|convert_rgb}}, {{color.opacity/100}});
+    #hs_cos_wrapper_{{ name }} {{css_selector}} {
+      {{property}}: rgba({{color.color|convert_rgb}}, {{color.opacity/100}});
+    }
   {%- endif -%}
 {%- endmacro -%}
 
 <div class="event-registration">
   {% require_css %}
   <style>
-    #hs_cos_wrapper_{{ name }} .event-registration {
-      {{outputColorIfSet('background-color', module.background_color)}}
-      {{outputColorIfSet('color', module.text_color)}}
-    }
-
-    #hs_cos_wrapper_{{ name }} .event-header {
-      {{outputColorIfSet('color', module.title_color)}}
-    }
-
-    #hs_cos_wrapper_{{ name }} .event-card__title {
-      {{outputColorIfSet('color', module.event_title_color)}}
-    }
-
-    #hs_cos_wrapper_{{ name }} .event-card {
-      {{outputColorIfSet('background-color', module.event_card_color)}}
-    }
-
-    #hs_cos_wrapper_{{ name }} div .eventCalendar .DayPicker .DayPicker-wrapper {
-      {{outputColorIfSet('background-color', module.calendar_color)}}
-    }
-
-    #hs_cos_wrapper_{{ name }} div .eventCalendar .DayPicker .DayPicker-wrapper .DayPicker-Day--today {
-      {{outputColorIfSet('background-color', module.calendar_highlight_color)}}
-    }
+    {{outputColorIfSet('background-color', module.background_color, '.event-registration')}}
+    {{outputColorIfSet('color', module.text_color, '.event_registration')}}
+    {{outputColorIfSet('color', module.title_color, '.event-header')}}
+    {{outputColorIfSet('color', module.event_title_color, '.event-card__title')}}
+    {{outputColorIfSet('background-color', module.event_card_color, '.event-card')}}
+    {{outputColorIfSet('background-color', module.calendar_color, 'div .eventCalendar .DayPicker .DayPicker-wrapper')}}
+    {{outputColorIfSet('background-color', module.calendar_highlight_color, 'div .eventCalendar .DayPicker .DayPicker-wrapper .DayPicker-Day--today')}}
   </style>
   {% end_require_css %}
   <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -6,9 +6,9 @@
   'map': get_asset_url('../../images/map.png'),
   'city': get_asset_url('../../images/city.jpg'), } %}
 
-{%- macro outputColorIfSet(color) -%}
+{%- macro outputColorIfSet(property, color) -%}
   {%- if color.color -%}
-    rgba({{color.color|convert_rgb}}, {{color.opacity/100}})
+    {{property}}: rgba({{color.color|convert_rgb}}, {{color.opacity/100}});
   {%- endif -%}
 {%- endmacro -%}
 
@@ -16,28 +16,28 @@
   {% require_css %}
   <style>
     #hs_cos_wrapper_{{ name }} .event-registration {
-      background-color:{{outputColorIfSet(module.background_color)}};
-      color:{{outputColorIfSet(module.text_color)}};
+      {{outputColorIfSet('background-color', module.background_color)}}
+      {{outputColorIfSet('color', module.text_color)}}
     }
 
     #hs_cos_wrapper_{{ name }} .event-header {
-      color: {{outputColorIfSet(module.title_color)}};
+      {{outputColorIfSet('color', module.title_color)}}
     }
 
     #hs_cos_wrapper_{{ name }} .event-card__title {
-      color: {{outputColorIfSet(module.event_title_color)}};
+      {{outputColorIfSet('color', module.event_title_color)}}
     }
 
     #hs_cos_wrapper_{{ name }} .event-card {
-      background-color: {{outputColorIfSet(module.event_card_color)}};
+      {{outputColorIfSet('background-color', module.event_card_color)}}
     }
 
     #hs_cos_wrapper_{{ name }} div .eventCalendar .DayPicker .DayPicker-wrapper {
-      background-color: {{outputColorIfSet(module.calendar_color)}};
+      {{outputColorIfSet('background-color', module.calendar_color)}}
     }
 
     #hs_cos_wrapper_{{ name }} div .eventCalendar .DayPicker .DayPicker-wrapper .DayPicker-Day--today {
-      background-color: {{outputColorIfSet(module.calendar_highlight_color)}};
+      {{outputColorIfSet('background-color', module.calendar_highlight_color)}}
     }
   </style>
   {% end_require_css %}

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -18,7 +18,7 @@
   {% require_css %}
   <style>
     {{outputColorIfSet('background-color', module.background_color, '.event-registration')}}
-    {{outputColorIfSet('color', module.text_color, '.event_registration')}}
+    {{outputColorIfSet('color', module.text_color, '.event-registration')}}
     {{outputColorIfSet('color', module.title_color, '.event-header')}}
     {{outputColorIfSet('color', module.event_title_color, '.event-card__title')}}
     {{outputColorIfSet('background-color', module.event_card_color, '.event-card')}}

--- a/src/modules/upcoming-events.module/module.html
+++ b/src/modules/upcoming-events.module/module.html
@@ -4,16 +4,16 @@
 {%- macro outputColorIfSet(color) -%}
   {%- if color.color -%}
     rgba({{color.color|convert_rgb}}, {{color.opacity/100}})
-  {%- else -%}
-    inherit
   {%- endif -%}
 {%- endmacro -%}
 
-<div class="upcoming-events"
-     style="background-color:{{outputColorIfSet(module.background_color)}};
-            color:{{outputColorIfSet(module.text_color)}};">
+<div class="upcoming-events">
   {% require_css %}
   <style>
+    #hs_cos_wrapper_{{ name }} .upcoming-events {
+      background-color:{{outputColorIfSet(module.background_color)}};
+      color:{{outputColorIfSet(module.text_color)}};
+    }
 
     #hs_cos_wrapper_{{ name }} .event-card {
       background-color: {{outputColorIfSet(module.event_card_color)}};
@@ -26,7 +26,6 @@
     #hs_cos_wrapper_{{ name }} .event-header {
       color: {{outputColorIfSet(module.title_color)}};
     }
-    
   </style>
   {% end_require_css %}
   <h2 class="event-header">Upcoming Events</h2>

--- a/src/modules/upcoming-events.module/module.html
+++ b/src/modules/upcoming-events.module/module.html
@@ -1,31 +1,22 @@
 {{ require_css(get_asset_url('../../upcoming-events.css')) }}
 {{ require_js(get_asset_url('../../upcoming-events.js'), 'footer') }}
 
-{%- macro outputColorIfSet(property, color) -%}
+{%- macro outputColorIfSet(property, color, css_selector) -%}
   {%- if color.color -%}
-    {{property}}: rgba({{color.color|convert_rgb}}, {{color.opacity/100}});
+    #hs_cos_wrapper_{{ name }} {{css_selector}} {
+      {{property}}: rgba({{color.color|convert_rgb}}, {{color.opacity/100}});
+    }
   {%- endif -%}
 {%- endmacro -%}
 
 <div class="upcoming-events">
   {% require_css %}
   <style>
-    #hs_cos_wrapper_{{ name }} .upcoming-events {
-      {{outputColorIfSet('background-color', module.background_color)}}
-      {{outputColorIfSet('color', module.text_color)}}
-    }
-
-    #hs_cos_wrapper_{{ name }} .event-card {
-      {{outputColorIfSet('background-color', module.event_card_color)}};
-    }
-
-    #hs_cos_wrapper_{{ name }} .event-card__title {
-      {{outputColorIfSet('color', module.event_title_color)}};
-    }
-
-    #hs_cos_wrapper_{{ name }} .event-header {
-      {{outputColorIfSet('color', module.title_color)}};
-    }
+    {{outputColorIfSet('background-color', module.background_color, '.upcoming-events')}}
+    {{outputColorIfSet('color', module.text_color, '.upcoming-events')}}
+    {{outputColorIfSet('background-color', module.event_card_color, '.event-card')}}
+    {{outputColorIfSet('color', module.title_color, '.event-header')}}
+    {{outputColorIfSet('color', module.event_title_color, '.event-card__title')}}
   </style>
   {% end_require_css %}
   <h2 class="event-header">Upcoming Events</h2>

--- a/src/modules/upcoming-events.module/module.html
+++ b/src/modules/upcoming-events.module/module.html
@@ -1,9 +1,9 @@
 {{ require_css(get_asset_url('../../upcoming-events.css')) }}
 {{ require_js(get_asset_url('../../upcoming-events.js'), 'footer') }}
 
-{%- macro outputColorIfSet(color) -%}
+{%- macro outputColorIfSet(property, color) -%}
   {%- if color.color -%}
-    rgba({{color.color|convert_rgb}}, {{color.opacity/100}})
+    {{property}}: rgba({{color.color|convert_rgb}}, {{color.opacity/100}});
   {%- endif -%}
 {%- endmacro -%}
 
@@ -11,20 +11,20 @@
   {% require_css %}
   <style>
     #hs_cos_wrapper_{{ name }} .upcoming-events {
-      background-color:{{outputColorIfSet(module.background_color)}};
-      color:{{outputColorIfSet(module.text_color)}};
+      {{outputColorIfSet('background-color', module.background_color)}}
+      {{outputColorIfSet('color', module.text_color)}}
     }
 
     #hs_cos_wrapper_{{ name }} .event-card {
-      background-color: {{outputColorIfSet(module.event_card_color)}};
+      {{outputColorIfSet('background-color', module.event_card_color)}};
     }
 
     #hs_cos_wrapper_{{ name }} .event-card__title {
-      color: {{outputColorIfSet(module.event_title_color)}};
+      {{outputColorIfSet('color', module.event_title_color)}};
     }
 
     #hs_cos_wrapper_{{ name }} .event-header {
-      color: {{outputColorIfSet(module.title_color)}};
+      {{outputColorIfSet('color', module.title_color)}};
     }
   </style>
   {% end_require_css %}


### PR DESCRIPTION
Reverts HubSpot/cms-event-registration#26 and adds color fields to the events app module once again. 

I noticed a bug with the calendar displayed in the Events app. When there are no inputs in the color fields, the calendar highlight appears blank. I will address this bug and test more vigorously before I merge this.  

