### PR TITLE
Switch to a single form and use event slugs instead of form guids to differentiate

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ Join [#events-app-beta](https://hubspotdev.slack.com/archives/C011GFF8KNZ) in th
    - Uses the `Events app` module in a page template
    - References the `Events` HubDB table, set up for dynamic pages
 
-7. Registrations are stored in the CRM using the [Forms API](https://developers.hubspot.com/docs/methods/forms/forms_overview). For each event that you create, you'll need to create a form and add that form ID to the HubDB entry. The form fields needed are:
+7. Registrations are stored in the CRM using the [Forms API](https://developers.hubspot.com/docs/methods/forms/forms_overview). You'll need to create a form and store its GUID in your portal's secrets so your functions have access to it. The form fields needed are:
    - First name
    - Last name
    - Email
+
+8. Use `yarn hs secrets add EVENTS_FORM_GUID <form-guid-goes-here>` to add the Event Registration form's id to your portal's secrets.
 
 ### Setting up membership
 

--- a/resources/events.hubdb.json
+++ b/resources/events.hubdb.json
@@ -28,8 +28,7 @@
       "name": "registered_attendee_count",
       "label": "Registered Attendee Count",
       "type": "NUMBER"
-    },
-    { "name": "form_guid", "label": "Event Form", "type": "TEXT" }
+    }
   ],
   "rows": [
     {
@@ -50,8 +49,7 @@
           "type": "image"
         },
         "event_capacity": 40,
-        "registered_attendee_count": 0,
-        "form_guid": "000-000-000"
+        "registered_attendee_count": 0
       }
     },
     {
@@ -72,8 +70,7 @@
           "type": "image"
         },
         "event_capacity": 40,
-        "registered_attendee_count": 0,
-        "form_guid": "000-000-000"
+        "registered_attendee_count": 0
       }
     },
     {
@@ -94,8 +91,7 @@
           "type": "image"
         },
         "event_capacity": 40,
-        "registered_attendee_count": 0,
-        "form_guid": "000-000-000"
+        "registered_attendee_count": 0
       }
     }
   ]

--- a/src/components/EventDetailsRegistration.js
+++ b/src/components/EventDetailsRegistration.js
@@ -35,7 +35,6 @@ const RegistrationForm = ({
     event.preventDefault();
 
     const params = {
-      form_guid: currentEvent.values.form_guid,
       rowId: currentEvent.id,
       pageUri: window.location.href,
       pageName: currentEvent.name,

--- a/src/components/RegisteredEventListings.js
+++ b/src/components/RegisteredEventListings.js
@@ -9,7 +9,9 @@ function RegisteredEventListings() {
   // const [submissions, setSubmissions] = useState([]);
   // const [submissionsLoaded, setSubmissionsLoaded] = useState(false);
   const [registeredEventSlugs, setRegisteredEventSlugs] = useState([]);
-  const [registeredEventSlugsLoaded, setRegisteredEventSlugsLoaded] = useState(false);
+  const [registeredEventSlugsLoaded, setRegisteredEventSlugsLoaded] = useState(
+    false,
+  );
 
   const getRegisteredEvents = async () => {
     // This function POSTs in order to pass cookies to the API and recieves a formSubmissions object

--- a/src/components/RegisteredEventListings.js
+++ b/src/components/RegisteredEventListings.js
@@ -6,8 +6,10 @@ import LoadingSpinner from './LoadingSpinner';
 
 function RegisteredEventListings() {
   const [state] = useContext(AppContext);
-  const [submissions, setSubmissions] = useState([]);
-  const [submissionsLoaded, setSubmissionsLoaded] = useState(false);
+  // const [submissions, setSubmissions] = useState([]);
+  // const [submissionsLoaded, setSubmissionsLoaded] = useState(false);
+  const [registeredEventSlugs, setRegisteredEventSlugs] = useState([]);
+  const [registeredEventSlugsLoaded, setRegisteredEventSlugsLoaded] = useState(false);
 
   const getRegisteredEvents = async () => {
     // This function POSTs in order to pass cookies to the API and recieves a formSubmissions object
@@ -21,21 +23,23 @@ function RegisteredEventListings() {
       body: JSON.stringify({}),
     });
     response = await response.json();
-    setSubmissionsLoaded(true);
-    setSubmissions(response.formSubmissions);
+    // setSubmissionsLoaded(true);
+    // setSubmissions(response.formSubmissions);
+    setRegisteredEventSlugsLoaded(true);
+    setRegisteredEventSlugs(response.slugs);
   };
 
   useEffect(() => {
     getRegisteredEvents();
   }, []);
 
-  return submissionsLoaded ? (
+  return registeredEventSlugsLoaded ? (
     <div className="registered-events">
-      {submissions.length > 0 ? (
+      {registeredEventSlugs.length > 0 ? (
         <>
           {state.events.map(
             (event, i) =>
-              submissions.indexOf(event.values.form_guid) != -1 && (
+              registeredEventSlugs.indexOf(event.path) != -1 && (
                 <Link to={`/events/${event.path}`} className="event-card__link">
                   <EventCard key={i} row={event} />
                 </Link>

--- a/src/event.functions/eventSignup.js
+++ b/src/event.functions/eventSignup.js
@@ -4,8 +4,8 @@ const request = util.promisify(require('request'));
 const HUBDB_API = 'https://api.hubspot.com/cms/v3/hubdb';
 const FORMS_API = `https://api.hsforms.com/submissions/v3/integration/submit`;
 
-exports.main = ({ body, accountId, secrets }, sendResponse) => {
-  if (!secrets.APIKEY) {
+exports.main = ({ body, accountId }, sendResponse) => {
+  if (!process.env.APIKEY) {
     sendResponse({
       statusCode: 403,
       body: { message: 'API key not present' },
@@ -13,7 +13,6 @@ exports.main = ({ body, accountId, secrets }, sendResponse) => {
   }
 
   const {
-    form_guid,
     email,
     firstName,
     lastName,
@@ -25,7 +24,7 @@ exports.main = ({ body, accountId, secrets }, sendResponse) => {
 
   const defaultParams = {
     portalId: accountId,
-    hapikey: secrets.APIKEY,
+    hapikey: process.env.APIKEY,
   };
 
   const getRow = async id => {
@@ -104,7 +103,7 @@ exports.main = ({ body, accountId, secrets }, sendResponse) => {
   };
 
   const updateContact = async () => {
-    const formApiWithGuid = `${FORMS_API}/${accountId}/${form_guid}`;
+    const formApiWithGuid = `${FORMS_API}/${accountId}/${process.env.EVENTS_FORM_GUID}`;
 
     const { statusCode, body } = await request({
       method: 'POST',

--- a/src/event.functions/eventSignup.js
+++ b/src/event.functions/eventSignup.js
@@ -7,7 +7,6 @@ const BASE_URL = `https://api.hubspot.com`;
 
 exports.main = ({ body, accountId, secrets }, sendResponse) => {
   const {
-    form_guid,
     email,
     firstName,
     lastName,
@@ -43,7 +42,7 @@ exports.main = ({ body, accountId, secrets }, sendResponse) => {
         qs: defaultParams,
         body: { values: updatedRowCell },
       });
-      const formApiWithGuid = `${FORMS_API}/${accountId}/${form_guid}`;
+      const formApiWithGuid = `${FORMS_API}/${accountId}/${secrets.EVENTS_FORM_GUID}`;
       const updateContactPromise = request({
         method: 'POST',
         json: true,

--- a/src/event.functions/eventSignup.js
+++ b/src/event.functions/eventSignup.js
@@ -12,15 +12,7 @@ exports.main = ({ body, accountId }, sendResponse) => {
     });
   }
 
-  const {
-    email,
-    firstName,
-    lastName,
-    rowId,
-    pageName,
-    pageUri,
-    utk,
-  } = body;
+  const { email, firstName, lastName, rowId, pageName, pageUri, utk } = body;
 
   const defaultParams = {
     portalId: accountId,

--- a/src/event.functions/eventSignup.js
+++ b/src/event.functions/eventSignup.js
@@ -5,9 +5,6 @@ const HUBDB_API = 'https://api.hubspot.com/cms/v3/hubdb';
 const FORMS_API = `https://api.hsforms.com/submissions/v3/integration/submit`;
 
 exports.main = ({ body, accountId, secrets }, sendResponse) => {
-<<<<<<< HEAD
-  const { email, firstName, lastName, rowId, pageName, pageUri, utk } = body;
-=======
   if (!secrets.APIKEY) {
     sendResponse({
       statusCode: 403,
@@ -25,42 +22,12 @@ exports.main = ({ body, accountId, secrets }, sendResponse) => {
     pageUri,
     utk,
   } = body;
->>>>>>> master
 
   const defaultParams = {
     portalId: accountId,
     hapikey: secrets.APIKEY,
   };
 
-<<<<<<< HEAD
-  const fetchRowPromise = request({
-    baseUrl: BASE_URL,
-    json: true,
-    uri: `${HUBDB_API}/tables/events/rows/${rowId}`,
-    qs: defaultParams,
-  });
-  fetchRowPromise
-    .then(response => {
-      const updatedRowCell = {
-        registered_attendee_count:
-          response.body.values.registered_attendee_count + 1,
-      };
-
-      const updateRowPromise = request({
-        baseUrl: BASE_URL,
-        method: 'PATCH',
-        json: true,
-        uri: `${HUBDB_API}/tables/events/rows/${rowId}/draft`,
-        qs: defaultParams,
-        body: { values: updatedRowCell },
-      });
-      const formApiWithGuid = `${FORMS_API}/${accountId}/${secrets.EVENTS_FORM_GUID}`;
-      const updateContactPromise = request({
-        method: 'POST',
-        json: true,
-        simple: true,
-        uri: formApiWithGuid,
-=======
   const getRow = async id => {
     const { statusCode, body } = await request({
       baseUrl: HUBDB_API,
@@ -72,7 +39,6 @@ exports.main = ({ body, accountId, secrets }, sendResponse) => {
     if (statusCode != 200) {
       sendResponse({
         statusCode: 500,
->>>>>>> master
         body: {
           message: body.message,
         },

--- a/src/event.functions/eventSignup.js
+++ b/src/event.functions/eventSignup.js
@@ -3,7 +3,7 @@ const request = util.promisify(require('request'));
 
 const HUBDB_API = 'https://api.hubspot.com/cms/v3/hubdb';
 const FORMS_API = `https://api.hsforms.com/submissions/v3/integration/submit`;
-const APIKEY = process.env.APIKEY;
+const { APIKEY, EVENTS_FORM_GUID } = process.env;
 
 exports.main = ({ body, accountId }, sendResponse) => {
   if (!APIKEY) {
@@ -96,7 +96,7 @@ exports.main = ({ body, accountId }, sendResponse) => {
   };
 
   const updateContact = async () => {
-    const formApiWithGuid = `${FORMS_API}/${accountId}/${process.env.EVENTS_FORM_GUID}`;
+    const formApiWithGuid = `${FORMS_API}/${accountId}/${EVENTS_FORM_GUID}`;
 
     const { statusCode, body } = await request({
       method: 'POST',

--- a/src/event.functions/eventSignup.js
+++ b/src/event.functions/eventSignup.js
@@ -6,15 +6,7 @@ const FORMS_API = `https://api.hsforms.com/submissions/v3/integration/submit`;
 const BASE_URL = `https://api.hubspot.com`;
 
 exports.main = ({ body, accountId, secrets }, sendResponse) => {
-  const {
-    email,
-    firstName,
-    lastName,
-    rowId,
-    pageName,
-    pageUri,
-    utk,
-  } = body;
+  const { email, firstName, lastName, rowId, pageName, pageUri, utk } = body;
 
   const defaultParams = {
     portalId: accountId,

--- a/src/event.functions/membership.js
+++ b/src/event.functions/membership.js
@@ -28,10 +28,12 @@ exports.main = ({ accountId, secrets, contact }, sendResponse) => {
   })
     .then(response => {
       const contactFormSubmissions = response.body['form-submissions'];
-      const eventFormSubmissions= contactFormSubmissions.filter(submission => submission['form-id'] === secrets.EVENTS_FORM_GUID);
+      const eventFormSubmissions = contactFormSubmissions.filter(
+        submission => submission['form-id'] === secrets.EVENTS_FORM_GUID,
+      );
 
       const slugs = eventFormSubmissions.map(submission =>
-        submission['page-url'].split('/').pop()
+        submission['page-url'].split('/').pop(),
       );
 
       sendResponse({

--- a/src/event.functions/membership.js
+++ b/src/event.functions/membership.js
@@ -4,13 +4,13 @@ const request = util.promisify(require('request'));
 const CONTACTS_API = '/contacts/v1/contact/vid';
 const BASE_URL = 'https://api.hubapi.com';
 
-exports.main = ({ accountId, secrets, contact }, sendResponse) => {
+exports.main = ({ accountId, contact }, sendResponse) => {
   const defaultParams = {
     portalId: accountId,
-    hapikey: secrets.APIKEY,
+    hapikey: process.env.APIKEY,
   };
 
-  if (!secrets.APIKEY) {
+  if (!process.env.APIKEY) {
     sendResponse({
       statusCode: 403,
       body: { message: 'API key not present' },
@@ -48,9 +48,10 @@ exports.main = ({ accountId, secrets, contact }, sendResponse) => {
   (async () => {
     try {
       const formSubmissions = await getContact(contact.vid);
-      const slugs = formSubmissions.map(submission =>
-        submission['page-url'].split('/').pop(),
-      );
+      const slugs = formSubmissions
+        .filter(submission => submission['form-id'] === process.env.EVENTS_FORM_GUID)
+        .map(registration => registration['page-url'].split('/').pop());
+
       const submittedFormsIds = formSubmissions.map(submission => {
         return submission['form-id'];
       });

--- a/src/event.functions/membership.js
+++ b/src/event.functions/membership.js
@@ -49,7 +49,9 @@ exports.main = ({ accountId, contact }, sendResponse) => {
     try {
       const formSubmissions = await getContact(contact.vid);
       const slugs = formSubmissions
-        .filter(submission => submission['form-id'] === process.env.EVENTS_FORM_GUID)
+        .filter(
+          submission => submission['form-id'] === process.env.EVENTS_FORM_GUID,
+        )
         .map(registration => registration['page-url'].split('/').pop());
 
       const submittedFormsIds = formSubmissions.map(submission => {

--- a/src/event.functions/membership.js
+++ b/src/event.functions/membership.js
@@ -28,18 +28,16 @@ exports.main = ({ accountId, secrets, contact }, sendResponse) => {
   })
     .then(response => {
       const contactFormSubmissions = response.body['form-submissions'];
+      const eventFormSubmissions= contactFormSubmissions.filter(submission => submission['form-id'] === secrets.EVENTS_FORM_GUID);
 
-      const submittedForms = contactFormSubmissions.map(submission => {
-        return submission['form-id'];
-      });
-      const slugs = contactFormSubmissions.map(submission =>
+      const slugs = eventFormSubmissions.map(submission =>
         submission['page-url'].split('/').pop()
       );
 
       sendResponse({
         statusCode: 200,
         body: {
-          formSubmissions: submittedForms,
+          eventFormSubmissions,
           contact,
           slugs,
         },

--- a/src/event.functions/membership.js
+++ b/src/event.functions/membership.js
@@ -32,12 +32,16 @@ exports.main = ({ accountId, secrets, contact }, sendResponse) => {
       const submittedForms = contactFormSubmissions.map(submission => {
         return submission['form-id'];
       });
+      const slugs = contactFormSubmissions.map(submission =>
+        submission['page-url'].split('/').pop()
+      );
 
       sendResponse({
         statusCode: 200,
         body: {
           formSubmissions: submittedForms,
           contact,
+          slugs,
         },
       });
     })

--- a/src/event.functions/serverless.json
+++ b/src/event.functions/serverless.json
@@ -1,7 +1,7 @@
 {
   "runtime": "nodejs10.x",
   "version": "1.0",
-  "secrets": ["APIKEY"],
+  "secrets": ["APIKEY", "EVENTS_FORM_GUID"],
   "endpoints": {
     "registration": {
       "method": "POST",


### PR DESCRIPTION
I've been thinking about this problem a bit and wanted to put up a PR to get my thoughts down.

My main motivation here is to reduce the need for events to have a 1:1 relationship with forms, as I can see that becoming untenable pretty quick. 

The reason for using the forms submission API is so we can capture the `hubspotutk` cookie and associate it with a contact vid on submission. We don't necessarily need to use the form submission to update contacts with event-specific information -- once a visitor is a known a contact, we could update properties / associated information directly via a different API. Said another way, the form primarily just functions to to associate the cookie with contact.

It's also possible we could use a hidden field to pass an event unique identifier (such as a slug or the rowId) to a contact property on form submission, but that would likely require creating a custom property in the portal (adding another step) and adding that field to the form. If we're going to the trouble of creating a property, I wonder if we could just use the get/update contact endpoint to update the contact directly and avoid additional fields on the form.

This approach...
* leverages the `pageUri` sent on form submission data to differentiate what event's being registered for, but it could easily use something else to differentiate between events. 
  * I think if we're happy with using the event page slug as the event's id, it makes sense to leverage the existing form submission data rather than create a custom property that mirrors existing functionality.
* expects the installer to store the created form GUID in portal secrets via `hs secrets add`, but could feasibly use a form selector module field instead (though this would require the end-user to select the right form in the upcoming events module's instances).

Depends on #40 