### PR TITLE
Add basic pagination

### DIFF
--- a/src/components/EventDetails.js
+++ b/src/components/EventDetails.js
@@ -16,14 +16,13 @@ const EventDetails = () => {
   const { slug } = useParams();
   const eventData = state.events;
 
-
   let event, prevEvent, nextEvent;
 
   eventData.forEach((e, i) => {
     if (e.path === slug) {
       event = e;
-      prevEvent = eventData[i-1];
-      nextEvent = eventData[i+1]
+      prevEvent = eventData[i - 1];
+      nextEvent = eventData[i + 1];
     }
   });
 
@@ -126,12 +125,16 @@ const EventDetails = () => {
                 </span>
               </div>
               <div className="event-details__pagination">
-              { prevEvent &&
-                <Link to={prevEvent.path} className="event-details__prevLink">&lt; Previous event</Link>
-                }
-                                { nextEvent &&
-                <Link to={nextEvent.path} className="event-details__nextLink">Next event &gt;</Link>
-                }
+                {prevEvent && (
+                  <Link to={prevEvent.path} className="event-details__prevLink">
+                    &lt; Previous event
+                  </Link>
+                )}
+                {nextEvent && (
+                  <Link to={nextEvent.path} className="event-details__nextLink">
+                    Next event &gt;
+                  </Link>
+                )}
               </div>
             </div>
           </div>

--- a/src/components/EventDetails.js
+++ b/src/components/EventDetails.js
@@ -7,7 +7,7 @@ import facebook from '../images/facebook.svg';
 import email from '../images/email.svg';
 import twitter from '../images/twitter.svg';
 import linkedin from '../images/linkedin.svg';
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { AppContext } from '../AppContext';
 import './EventDetails.scss';
 
@@ -16,7 +16,17 @@ const EventDetails = () => {
   const { slug } = useParams();
   const eventData = state.events;
 
-  const event = eventData.find(event => event.path === slug);
+
+  let event, prevEvent, nextEvent;
+
+  eventData.forEach((e, i) => {
+    if (e.path === slug) {
+      event = e;
+      prevEvent = eventData[i-1];
+      nextEvent = eventData[i+1]
+    }
+  });
+
   const eventImage =
     event && event.values.feature_image ? event.values.feature_image.url : '';
 
@@ -114,6 +124,14 @@ const EventDetails = () => {
                     </a>
                   </div>
                 </span>
+              </div>
+              <div className="event-details__pagination">
+              { prevEvent &&
+                <Link to={prevEvent.path} className="event-details__prevLink">Prev</Link>
+                }
+                                { nextEvent &&
+                <Link to={nextEvent.path} className="event-details__nextLink">Next</Link>
+                }
               </div>
             </div>
           </div>

--- a/src/components/EventDetails.js
+++ b/src/components/EventDetails.js
@@ -127,10 +127,10 @@ const EventDetails = () => {
               </div>
               <div className="event-details__pagination">
               { prevEvent &&
-                <Link to={prevEvent.path} className="event-details__prevLink">Previous event</Link>
+                <Link to={prevEvent.path} className="event-details__prevLink">&lt; Previous event</Link>
                 }
                                 { nextEvent &&
-                <Link to={nextEvent.path} className="event-details__nextLink">Next event</Link>
+                <Link to={nextEvent.path} className="event-details__nextLink">Next event &gt;</Link>
                 }
               </div>
             </div>

--- a/src/components/EventDetails.js
+++ b/src/components/EventDetails.js
@@ -127,10 +127,10 @@ const EventDetails = () => {
               </div>
               <div className="event-details__pagination">
               { prevEvent &&
-                <Link to={prevEvent.path} className="event-details__prevLink">Prev</Link>
+                <Link to={prevEvent.path} className="event-details__prevLink">Previous event</Link>
                 }
                                 { nextEvent &&
-                <Link to={nextEvent.path} className="event-details__nextLink">Next</Link>
+                <Link to={nextEvent.path} className="event-details__nextLink">Next event</Link>
                 }
               </div>
             </div>

--- a/src/components/EventDetails.scss
+++ b/src/components/EventDetails.scss
@@ -13,9 +13,11 @@
 .event-details__column {
   flex: 1;
 }
-.event-details__column--sidebar {
-  flex: 0 0 360px;
-  margin-left: 40px;
+@media screen and (min-width: 1000px) {
+  .event-details__column--sidebar {
+    flex: 0 0 360px;
+    margin-left: 40px;
+  }
 }
 .event-details__image {
   overflow: hidden;
@@ -92,6 +94,9 @@
   margin-top: 15px;
   margin-bottom: 50px;
 }
+.event-details__pagination {
+  margin-bottom: 20px;
+}
 .event-details__nextLink {
   display: inline-block;
   float: left;
@@ -100,7 +105,6 @@
   display: inline-block;
   float: right;
 }
-
 
 .share-icon {
   height: 25px;

--- a/src/components/EventDetails.scss
+++ b/src/components/EventDetails.scss
@@ -92,6 +92,15 @@
   margin-top: 15px;
   margin-bottom: 50px;
 }
+.event-details__nextLink {
+  display: inline-block;
+  float: left;
+}
+.event-details__nextLink {
+  display: inline-block;
+  float: right;
+}
+
 
 .share-icon {
   height: 25px;


### PR DESCRIPTION
Adds a previous and next link to the event details view to allow users to page through events:

![image](https://user-images.githubusercontent.com/9009552/80023666-df5e6180-84ab-11ea-9434-35f7767095d8.png)

Fixes #31 
