### PR TITLE
Regroup and reorganize Events app color fields

### DIFF
--- a/src/modules/events-app.module/fields.json
+++ b/src/modules/events-app.module/fields.json
@@ -68,22 +68,13 @@
         "required": false,
         "locked": false,
         "default": {}
-      },
-      {
-        "label": "Icon color",
-        "name": "icon_color_card",
-        "required": false,
-        "locked": false,
-        "type": "color",
-        "default": {}
       }
     ],
     "tab": "CONTENT",
     "type": "group",
     "default": {
       "card_color": {},
-      "font_color_card": {},
-      "icon_color_card": {}
+      "font_color_card": {}
     }
   },
   {
@@ -140,21 +131,12 @@
             "required": false,
             "locked": false,
             "default": {}
-          },
-          {
-            "label": "Border color",
-            "name": "border_color_form_fields",
-            "required": false,
-            "locked": false,
-            "type": "color",
-            "default": {}
           }
         ],
         "tab": "CONTENT",
         "type": "group",
         "default": {
-          "background_color_form_fields": {},
-          "border_color_form_fields": {}
+          "background_color_form_fields": {}
         }
       },
       {
@@ -208,8 +190,7 @@
         "font_color_form_title": {}
       },
       "form_fields": {
-        "background_color_form_fields": {},
-        "border_color_form_fields": {}
+        "background_color_form_fields": {}
       },
       "form_submit_button": {
         "background_color_form_button": {}

--- a/src/modules/events-app.module/fields.json
+++ b/src/modules/events-app.module/fields.json
@@ -55,7 +55,7 @@
     "children": [
       {
         "label": "Card color",
-        "name": "card_color",
+        "name": "background_color_card",
         "type": "color",
         "required": false,
         "locked": false,
@@ -85,5 +85,123 @@
       "font_color_card": {},
       "icon_color_card": {}
     }
+  },
+  {
+  "label" : "Form",
+  "name" : "event_form",
+  "required" : false,
+  "locked" : false,
+  "visibility" : {
+    "controlling_field" : "customize_styles",
+    "controlling_value_regex" : "true",
+    "operator" : "EQUAL"
+  },
+  "children" : [ {
+    "label" : "Title",
+    "name" : "form_title",
+    "required" : false,
+    "locked" : false,
+    "children" : [ {
+      "label" : "Background color",
+      "name" : "background_color_form_title",
+      "type" : "color",
+      "required" : false,
+      "locked" : false,
+      "default" : {}
+    }, {
+      "label" : "Font color",
+      "name" : "font_color_form_title",
+      "type" : "color",
+      "required" : false,
+      "locked" : false,
+      "default" : {}
+    } ],
+    "tab" : "CONTENT",
+    "type" : "group",
+    "default" : {
+      "background_color_form_title" : {},
+      "font_color_form_title" : {}
+    }
+  }, {
+    "label" : "Fields",
+    "name" : "form_fields",
+    "required" : false,
+    "locked" : false,
+    "children" : [ {
+      "label" : "Background color",
+      "name" : "background_color_form_fields",
+      "type" : "color",
+      "required" : false,
+      "locked" : false,
+      "default" : {}
+    }, {
+      "label" : "Border color",
+      "name" : "border_color_form_fields",
+      "required" : false,
+      "locked" : false,
+      "type" : "color",
+      "default" : {}
+    } ],
+    "tab" : "CONTENT",
+    "type" : "group",
+    "default" : {
+      "background_color_form_fields" : {},
+      "border_color_form_fields" : {}
+    }
+  }, {
+    "label" : "Submit",
+    "name" : "form_submit_button",
+    "required" : false,
+    "locked" : false,
+    "children" : [ {
+      "label" : "Button color",
+      "name" : "background_color_form_button",
+      "required" : false,
+      "type" : "color",
+      "locked" : false,
+      "default" : {}
+    } ],
+    "tab" : "CONTENT",
+    "type" : "group",
+    "default" : {
+      "background_color_form_button" : {}
+    }
+  }, {
+    "label" : "Background",
+    "name" : "form_background",
+    "required" : false,
+    "locked" : false,
+    "children" : [ {
+      "label" : "Form background color",
+      "name" : "background_color_form",
+      "type" : "color",
+      "required" : false,
+      "locked" : false,
+      "default" : {}
+    } ],
+    "tab" : "CONTENT",
+    "type" : "group",
+    "default" : {
+      "background_color_form" : {}
+    }
+  } ],
+  "tab" : "CONTENT",
+  "type" : "group",
+  "default" : {
+    "form_title" : {
+      "background_color_form_title" : {},
+      "font_color_form_title" : {}
+    },
+    "form_fields" : {
+      "background_color_form_fields" : {},
+      "border_color_form_fields" : {}
+    },
+    "form_submit_button" : {
+      "background_color_form_button" : {}
+    },
+    "form_background" : {
+      "background_color_form" : {}
+    }
   }
+} ]
 ]

--- a/src/modules/events-app.module/fields.json
+++ b/src/modules/events-app.module/fields.json
@@ -1,58 +1,89 @@
 [
   {
-    "label": "Background color",
-    "name": "background_color",
-    "type": "color",
+    "label": "Customize styles",
+    "name": "customize_styles",
+    "type": "boolean",
     "required": false,
     "locked": false,
-    "default": {}
+    "default": false
   },
   {
-    "label": "Event card color",
-    "name": "event_card_color",
-    "type": "color",
+    "label": "Filter menu styles",
+    "name": "filter_menu_styles",
     "required": false,
     "locked": false,
-    "default": {}
+    "visibility": {
+      "controlling_field": "customize_styles",
+      "controlling_value_regex": "true",
+      "operator": "EQUAL"
+    },
+    "children": [
+      {
+        "label": "Background color",
+        "name": "background_color_filter_bar",
+        "type": "color",
+        "required": false,
+        "locked": false,
+        "default": {}
+      },
+      {
+        "label": "Font color",
+        "name": "font_color_filter_bar",
+        "type": "color",
+        "required": false,
+        "locked": false,
+        "default": {}
+      }
+    ],
+    "tab": "CONTENT",
+    "type": "group",
+    "default": {
+      "background_color_filter_bar": {},
+      "font_color_filter_bar": {}
+    }
   },
   {
-    "label": "Calendar color",
-    "name": "calendar_color",
-    "type": "color",
+    "label": "Card styles",
+    "name": "card_styles",
     "required": false,
     "locked": false,
-    "default": {}
-  },
-  {
-    "label": "Calendar highlight color",
-    "name": "calendar_highlight_color",
-    "type": "color",
-    "required": false,
-    "locked": false,
-    "default": {}
-  },
-  {
-    "label": "Text color",
-    "name": "text_color",
-    "type": "color",
-    "required": false,
-    "locked": false,
-    "default": {}
-  },
-  {
-    "label": "Title color",
-    "name": "title_color",
-    "type": "color",
-    "required": false,
-    "locked": false,
-    "default": {}
-  },
-  {
-    "label": "Event title color",
-    "name": "event_title_color",
-    "type": "color",
-    "required": false,
-    "locked": false,
-    "default": {}
+    "visibility": {
+      "controlling_field": "customize_styles",
+      "controlling_value_regex": "true",
+      "operator": "EQUAL"
+    },
+    "children": [
+      {
+        "label": "Card color",
+        "name": "card_color",
+        "type": "color",
+        "required": false,
+        "locked": false,
+        "default": {}
+      },
+      {
+        "label": "Font color",
+        "name": "font_color_card",
+        "type": "color",
+        "required": false,
+        "locked": false,
+        "default": {}
+      },
+      {
+        "label": "Icon color",
+        "name": "icon_color_card",
+        "required": false,
+        "locked": false,
+        "type": "color",
+        "default": {}
+      }
+    ],
+    "tab": "CONTENT",
+    "type": "group",
+    "default": {
+      "card_color": {},
+      "font_color_card": {},
+      "icon_color_card": {}
+    }
   }
 ]

--- a/src/modules/events-app.module/fields.json
+++ b/src/modules/events-app.module/fields.json
@@ -87,121 +87,136 @@
     }
   },
   {
-  "label" : "Form",
-  "name" : "event_form",
-  "required" : false,
-  "locked" : false,
-  "visibility" : {
-    "controlling_field" : "customize_styles",
-    "controlling_value_regex" : "true",
-    "operator" : "EQUAL"
-  },
-  "children" : [ {
-    "label" : "Title",
-    "name" : "form_title",
-    "required" : false,
-    "locked" : false,
-    "children" : [ {
-      "label" : "Background color",
-      "name" : "background_color_form_title",
-      "type" : "color",
-      "required" : false,
-      "locked" : false,
-      "default" : {}
-    }, {
-      "label" : "Font color",
-      "name" : "font_color_form_title",
-      "type" : "color",
-      "required" : false,
-      "locked" : false,
-      "default" : {}
-    } ],
-    "tab" : "CONTENT",
-    "type" : "group",
-    "default" : {
-      "background_color_form_title" : {},
-      "font_color_form_title" : {}
-    }
-  }, {
-    "label" : "Fields",
-    "name" : "form_fields",
-    "required" : false,
-    "locked" : false,
-    "children" : [ {
-      "label" : "Background color",
-      "name" : "background_color_form_fields",
-      "type" : "color",
-      "required" : false,
-      "locked" : false,
-      "default" : {}
-    }, {
-      "label" : "Border color",
-      "name" : "border_color_form_fields",
-      "required" : false,
-      "locked" : false,
-      "type" : "color",
-      "default" : {}
-    } ],
-    "tab" : "CONTENT",
-    "type" : "group",
-    "default" : {
-      "background_color_form_fields" : {},
-      "border_color_form_fields" : {}
-    }
-  }, {
-    "label" : "Submit",
-    "name" : "form_submit_button",
-    "required" : false,
-    "locked" : false,
-    "children" : [ {
-      "label" : "Button color",
-      "name" : "background_color_form_button",
-      "required" : false,
-      "type" : "color",
-      "locked" : false,
-      "default" : {}
-    } ],
-    "tab" : "CONTENT",
-    "type" : "group",
-    "default" : {
-      "background_color_form_button" : {}
-    }
-  }, {
-    "label" : "Background",
-    "name" : "form_background",
-    "required" : false,
-    "locked" : false,
-    "children" : [ {
-      "label" : "Form background color",
-      "name" : "background_color_form",
-      "type" : "color",
-      "required" : false,
-      "locked" : false,
-      "default" : {}
-    } ],
-    "tab" : "CONTENT",
-    "type" : "group",
-    "default" : {
-      "background_color_form" : {}
-    }
-  } ],
-  "tab" : "CONTENT",
-  "type" : "group",
-  "default" : {
-    "form_title" : {
-      "background_color_form_title" : {},
-      "font_color_form_title" : {}
+    "label": "Form",
+    "name": "event_form",
+    "required": false,
+    "locked": false,
+    "visibility": {
+      "controlling_field": "customize_styles",
+      "controlling_value_regex": "true",
+      "operator": "EQUAL"
     },
-    "form_fields" : {
-      "background_color_form_fields" : {},
-      "border_color_form_fields" : {}
-    },
-    "form_submit_button" : {
-      "background_color_form_button" : {}
-    },
-    "form_background" : {
-      "background_color_form" : {}
+    "children": [
+      {
+        "label": "Title",
+        "name": "form_title",
+        "required": false,
+        "locked": false,
+        "children": [
+          {
+            "label": "Background color",
+            "name": "background_color_form_title",
+            "type": "color",
+            "required": false,
+            "locked": false,
+            "default": {}
+          },
+          {
+            "label": "Font color",
+            "name": "font_color_form_title",
+            "type": "color",
+            "required": false,
+            "locked": false,
+            "default": {}
+          }
+        ],
+        "tab": "CONTENT",
+        "type": "group",
+        "default": {
+          "background_color_form_title": {},
+          "font_color_form_title": {}
+        }
+      },
+      {
+        "label": "Fields",
+        "name": "form_fields",
+        "required": false,
+        "locked": false,
+        "children": [
+          {
+            "label": "Background color",
+            "name": "background_color_form_fields",
+            "type": "color",
+            "required": false,
+            "locked": false,
+            "default": {}
+          },
+          {
+            "label": "Border color",
+            "name": "border_color_form_fields",
+            "required": false,
+            "locked": false,
+            "type": "color",
+            "default": {}
+          }
+        ],
+        "tab": "CONTENT",
+        "type": "group",
+        "default": {
+          "background_color_form_fields": {},
+          "border_color_form_fields": {}
+        }
+      },
+      {
+        "label": "Submit",
+        "name": "form_submit_button",
+        "required": false,
+        "locked": false,
+        "children": [
+          {
+            "label": "Button color",
+            "name": "background_color_form_button",
+            "required": false,
+            "type": "color",
+            "locked": false,
+            "default": {}
+          }
+        ],
+        "tab": "CONTENT",
+        "type": "group",
+        "default": {
+          "background_color_form_button": {}
+        }
+      },
+      {
+        "label": "Background",
+        "name": "form_background",
+        "required": false,
+        "locked": false,
+        "children": [
+          {
+            "label": "Form background color",
+            "name": "background_color_form",
+            "type": "color",
+            "required": false,
+            "locked": false,
+            "default": {}
+          }
+        ],
+        "tab": "CONTENT",
+        "type": "group",
+        "default": {
+          "background_color_form": {}
+        }
+      }
+    ],
+    "tab": "CONTENT",
+    "type": "group",
+    "default": {
+      "form_title": {
+        "background_color_form_title": {},
+        "font_color_form_title": {}
+      },
+      "form_fields": {
+        "background_color_form_fields": {},
+        "border_color_form_fields": {}
+      },
+      "form_submit_button": {
+        "background_color_form_button": {}
+      },
+      "form_background": {
+        "background_color_form": {}
+      }
     }
   }
-} ]
 ]

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -17,13 +17,14 @@
 <div class="event-registration">
   {% require_css %}
   <style>
-    {{outputColorIfSet('background-color', module.background_color, '.event-registration')}}
-    {{outputColorIfSet('color', module.text_color, '.event-registration')}}
-    {{outputColorIfSet('color', module.title_color, '.event-header')}}
-    {{outputColorIfSet('color', module.event_title_color, '.event-card__title')}}
-    {{outputColorIfSet('background-color', module.event_card_color, '.event-card')}}
-    {{outputColorIfSet('background-color', module.calendar_color, 'div .eventCalendar .DayPicker .DayPicker-wrapper')}}
-    {{outputColorIfSet('background-color', module.calendar_highlight_color, 'div .eventCalendar .DayPicker .DayPicker-wrapper .DayPicker-Day--today')}}
+    {{outputColorIfSet('background-color', module.filter_menu_styles.background_color_filter_bar, '.filter-bar')}}
+    {{outputColorIfSet('color', module.filter_menu_styles.font_color_filter_bar, '.filter-bar')}}
+
+    {{outputColorIfSet('background-color', module.card_styles.background_color_card, '.event-card')}}
+    {{outputColorIfSet('color', module.card_styles.font_color_card, '.event-card__title')}}
+    {{outputColorIfSet('color', module.card_styles.font_color_card, '.event-registration')}}
+
+    
   </style>
   {% end_require_css %}
   <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -17,21 +17,23 @@
 <div class="event-registration">
   {% require_css %}
   <style>
-    {{outputColorIfSet('background-color', module.filter_menu_styles.background_color_filter_bar, '.filter-bar')}}
-    {{outputColorIfSet('color', module.filter_menu_styles.font_color_filter_bar, '.filter-bar')}}
+    {% if module.customize_styles %}
+      {{outputColorIfSet('background-color', module.filter_menu_styles.background_color_filter_bar, '.filter-bar')}}
+      {{outputColorIfSet('color', module.filter_menu_styles.font_color_filter_bar, '.filter-bar')}}
 
-    {{outputColorIfSet('background-color', module.card_styles.background_color_card, '.event-card')}}
-    {{outputColorIfSet('color', module.card_styles.font_color_card, '.event-card__title')}}
-    {{outputColorIfSet('color', module.card_styles.font_color_card, '.event-card__column')}}
+      {{outputColorIfSet('background-color', module.card_styles.background_color_card, '.event-card')}}
+      {{outputColorIfSet('color', module.card_styles.font_color_card, '.event-card__title')}}
+      {{outputColorIfSet('color', module.card_styles.font_color_card, '.event-card__column')}}
 
-    {{outputColorIfSet('background-color', module.event_form.form_title.background_color_form_title, '.event-details__registration--title')}}
-    {{outputColorIfSet('color', module.event_form.form_title.font_color_form_title, '.event-details__registration--title')}}
+      {{outputColorIfSet('background-color', module.event_form.form_title.background_color_form_title, '.event-details__registration--  title')}}
+      {{outputColorIfSet('color', module.event_form.form_title.font_color_form_title, '.event-details__registration--title')}}
 
-    {{outputColorIfSet('background-color', module.event_form.form_fields.background_color_form_fields, '.event-details__registration__input')}}
+      {{outputColorIfSet('background-color', module.event_form.form_fields.background_color_form_fields, '.event-  details__registration__input')}}
 
-    {{outputColorIfSet('background-color', module.event_form.form_submit_button.background_color_form_button, '.event-button')}}
+      {{outputColorIfSet('background-color', module.event_form.form_submit_button.background_color_form_button, '.event-button')}}
 
-    {{outputColorIfSet('background-color', module.event_form.form_background.background_color_form, '.event-details__registration')}}
+      {{outputColorIfSet('background-color', module.event_form.form_background.background_color_form, '.event-details__registration')}}
+    {% endif %}
   </style>
   {% end_require_css %}
   <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -28,7 +28,6 @@
     {{outputColorIfSet('color', module.event_form.form_title.font_color_form_title, '.event-details__registration--title')}}
 
     {{outputColorIfSet('background-color', module.event_form.form_fields.background_color_form_fields, '.event-details__registration__input')}}
-    {{outputColorIfSet('border-color', module.event_form.form_fields.border_color_form_fields, '.event-details__registration__input')}}
 
     {{outputColorIfSet('background-color', module.event_form.form_submit_button.background_color_form_button, '.event-button')}}
 

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -22,9 +22,17 @@
 
     {{outputColorIfSet('background-color', module.card_styles.background_color_card, '.event-card')}}
     {{outputColorIfSet('color', module.card_styles.font_color_card, '.event-card__title')}}
-    {{outputColorIfSet('color', module.card_styles.font_color_card, '.event-registration')}}
+    {{outputColorIfSet('color', module.card_styles.font_color_card, '.event-card__column')}}
 
-    
+    {{outputColorIfSet('background-color', module.event_form.form_title.background_color_form_title, '.event-details__registration--title')}}
+    {{outputColorIfSet('color', module.event_form.form_title.font_color_form_title, '.event-details__registration--title')}}
+
+    {{outputColorIfSet('background-color', module.event_form.form_fields.background_color_form_fields, '.event-details__registration__input')}}
+    {{outputColorIfSet('border-color', module.event_form.form_fields.border_color_form_fields, '.event-details__registration__input')}}
+
+    {{outputColorIfSet('background-color', module.event_form.form_submit_button.background_color_form_button, '.event-button')}}
+
+    {{outputColorIfSet('background-color', module.event_form.form_background.background_color_form, '.event-details__registration')}}
   </style>
   {% end_require_css %}
   <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
Fixes #47.

I've regrouped and reorganized the color fields in the Events app into three groups: 1) Filter menu styles, 2) Card styles, and 3) Form. These three groups only appear if the customer toggles the 'Customize style' boolean, just as we discussed here (https://github.com/HubSpot/cms-event-registration/pull/27#discussion_r414103613). 

I encountered three main issues while working on this PR:

ISSUE 1: Originally, in her mock, Amanda suggested the third field group be the 'Event details style' group, which itself would have two groups: Form and Breadcrumb. While I was attempting to create the Event detail styles group, I received the following error in the Design Manager: 'Field groups can be nested at most 3 deep'. It won't be possible to implement the Event detail styles group with the two nested groups of Form and Breadcrumb, since Form itself has nested groups. 

I discussed this with Amanda, and we decided to make Form into its own group. If anyone has any feedback on this, please do let me know.

--- 

ISSUE 2: Both Tori and Amanda have suggested that we add a color field to change the color of the location, time, and people icons on each event card. I love this idea, but this has proved a bit challenging to implement, since these icons are svg files. 

I'll either need 1) to change the way we are importing the svg files into the EventCard React component, or else 2) to use a css property to change the svg's fill, such as filter. I think both solutions present their own problems, since Option 1 will complicate the React component a fair bit, and Option 2 doesn't always render the correct color. 

Does anyone have a less complicated way to change the fill of a svg file? If not, how do we feel about removing this particular field? 

---

ISSUE 3: I ran into a bit of trouble changing the border color for the form fields on the event detail page. I was working in the vitality theme at first, and the theme's CSS overrode. the border color and radius. I think I'm running up against @levinkeo's warning that it might prove very difficult to manipulate the CSS of cms apps, when they are being placed in themes with completely different styling. 

---

cc @gcorne @levinkeo (I will also Slack this PR to Tori and Amanda, as well. I seem to remember that Anthony set up a public GitHub account for Amanda, but I can't seem to link to it) 
