### PR TITLE
Un-reverse Upcoming Events module listing order

### DIFF
--- a/src/UpcomingEvents.js
+++ b/src/UpcomingEvents.js
@@ -9,7 +9,7 @@ import './scss/upcoming-events.scss';
 
 function UpcomingEvents() {
   const [state] = useContext(AppContext);
-  const upcomingEvents = state.events.reverse().slice(0, 3);
+  const upcomingEvents = state.events.slice(0, 3);
   const eventsLoaded = state.eventsLoaded;
 
   return eventsLoaded === eventLoadingStatus.SUCCEEDED ? (


### PR DESCRIPTION
Some time ago, we started fetching events already sorted by start date, though the upcoming events module wasn't updated. This change ensures the upcoming events module is displaying the next, upcoming three events instead of the last three.