### PR TITLE
Improve endpoint error handling, naming, and methods

### DIFF
--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -36,7 +36,7 @@ const AppProvider = props => {
       cache: 'no-cache',
       headers: {
         'Content-Type': 'application/json',
-      }
+      },
     });
     response = await response.json();
 

--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -30,14 +30,13 @@ const AppProvider = props => {
 
   const getUserDetails = async () => {
     // This function POSTs in order to pass cookies to the API and recieves a contact object
-    let response = await fetch(`/_hcms/api/registration`, {
-      method: 'POST',
+    let response = await fetch(`/_hcms/api/authenticate`, {
+      method: 'GET',
       mode: 'same-origin',
       cache: 'no-cache',
       headers: {
         'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({}),
+      }
     });
     response = await response.json();
 

--- a/src/components/EventDetailsRegistration.js
+++ b/src/components/EventDetailsRegistration.js
@@ -48,7 +48,7 @@ const RegistrationForm = ({
     if (handleFormValidation()) {
       handleLoadingState();
 
-      const response = await fetch(`/_hcms/api/registration/new`, {
+      const response = await fetch(`/_hcms/api/register`, {
         method: 'POST',
         mode: 'same-origin',
         cache: 'no-cache',

--- a/src/components/RegisteredEventListings.js
+++ b/src/components/RegisteredEventListings.js
@@ -12,7 +12,7 @@ function RegisteredEventListings() {
   );
 
   const getRegisteredEvents = async () => {
-    // This function POSTs in order to pass cookies to the API and recieves a formSubmissions object
+    // This function fetchs same-origin in order to pass cookies to the API and recieves a formSubmissions object
     let response = await fetch(`/_hcms/api/authenticate`, {
       method: 'GET',
       mode: 'same-origin',

--- a/src/components/RegisteredEventListings.js
+++ b/src/components/RegisteredEventListings.js
@@ -19,7 +19,7 @@ function RegisteredEventListings() {
       cache: 'no-cache',
       headers: {
         'Content-Type': 'application/json',
-      }
+      },
     });
     response = await response.json();
     setRegisteredEventSlugsLoaded(true);

--- a/src/components/RegisteredEventListings.js
+++ b/src/components/RegisteredEventListings.js
@@ -13,14 +13,13 @@ function RegisteredEventListings() {
 
   const getRegisteredEvents = async () => {
     // This function POSTs in order to pass cookies to the API and recieves a formSubmissions object
-    let response = await fetch(`/_hcms/api/registration`, {
-      method: 'POST',
+    let response = await fetch(`/_hcms/api/authenticate`, {
+      method: 'GET',
       mode: 'same-origin',
       cache: 'no-cache',
       headers: {
         'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({}),
+      }
     });
     response = await response.json();
     setRegisteredEventSlugsLoaded(true);

--- a/src/event.functions/eventSignup.js
+++ b/src/event.functions/eventSignup.js
@@ -43,7 +43,7 @@ exports.main = ({ body, accountId }, sendResponse) => {
   const incrementAttendeeCount = async id => {
     const { registered_attendee_count } = await getRow(id);
 
-    if (!registered_attendee_count) {
+    if (registered_attendee_count == null || registered_attendee_count < 0) {
       sendResponse({
         statusCode: 500,
         body: { message: 'Invalid attendee count value' },

--- a/src/event.functions/membership.js
+++ b/src/event.functions/membership.js
@@ -20,7 +20,7 @@ exports.main = ({ accountId, contact }, sendResponse) => {
 
   if (!contact || !contact.isLoggedIn) {
     sendResponse({
-      statusCode: 403,
+      statusCode: 401,
       body: {
         message: 'User is not authenticated',
       },

--- a/src/event.functions/serverless.json
+++ b/src/event.functions/serverless.json
@@ -3,11 +3,11 @@
   "version": "1.0",
   "secrets": ["APIKEY", "EVENTS_FORM_GUID"],
   "endpoints": {
-    "registration": {
-      "method": "POST",
+    "authenticate": {
+      "method": "GET",
       "file": "membership.js"
     },
-    "registration/new": {
+    "register": {
       "method": "POST",
       "file": "eventSignup.js"
     }


### PR DESCRIPTION
Resolves #41 
* Renames `registration/new` -> `/register`
* Renames `registration` -> `/authenticate` and changes method to `GET`
* Throws 401 instead of 403 when a user is not signed in / a new visitor
* Adjusts error handling in `errorSignup.js (/register)` for events with an initial attendee count of 0.