### PR TITLE
lowercase 'b' in createHubDb.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "deploy": "hs upload dist event-registration",
     "lint": "eslint src && prettier --check 'src/**/*.js' 'src/**/*.json'",
     "prettier:write": "prettier --write 'src/**/*.js' 'src/**/*.json'",
-    "create-table": "node ./scripts/createHubDB.js create --table_path ./resources/events.hubdb.json"
+    "create-table": "node ./scripts/createHubDb.js create --table_path ./resources/events.hubdb.json"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Resolves #61 

Thanks for pointing this out @dannio! This never came up on our end because I believe the mac filesystem is case-insensitive and no one caught it.
