### PR TITLE
Remove a reference to webkit in scss file

### DIFF
--- a/src/components/EventFilterBar.scss
+++ b/src/components/EventFilterBar.scss
@@ -96,7 +96,6 @@
     height: 1rem;
     transform: rotate(45deg);
     position: absolute;
-    -webkit-transform: rotate(45deg);
     width: 1rem;
   }
 


### PR DESCRIPTION
I removed a leftover vendor prefix from the `EventFilterBar.scss` file. 