### PR TITLE
Revisit slug configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ _Note: In order to set up membership, your account will need a [connected domain
 
 8. Create a [dynamic list](https://app.hubspot.com/l/contacts/lists) that includes contacts that have filled out any event form
 9. Create a `my events` page in your portal that:
-   - Uses the `Events app` module in a page template and has the form you created in `6.` selected in the module fields. Under the `my events` field, select the page you're currently editing.
-   - The page shouldn't be dynamic.
+   - Uses the `Events app` module in a page template and has the form you created in `6.` selected in the module fields.
+   - Unlike the `events` page we created in step `7.`, the `my events` page shouldn't be using HubDB dynamic pages.
    - Under "Control audience access for page", select "Private - Registration required" and select the list you made in the previous step
 10. In the `Events app` module on the 'events listing' page you created in step `7.`, select the `my events` page you just created.
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ Join [#events-app-beta](https://hubspotdev.slack.com/archives/C011GFF8KNZ) in th
    - First name
    - Last name
    - Email
-7. Create a page in your portal that:
-
-   - Has the slug `/events/`
+7. Create an `events` page in your portal that:
    - Uses the `Events app` module in a page template and has the form you created in `6.` selected in the module fields.
    - References the `Events` HubDB table, set up for dynamic pages
 
@@ -35,10 +33,15 @@ Join [#events-app-beta](https://hubspotdev.slack.com/archives/C011GFF8KNZ) in th
 _Note: In order to set up membership, your account will need a [connected domain](https://knowledge.hubspot.com/cos-general/connect-a-domain-to-hubspot)_
 
 8. Create a [dynamic list](https://app.hubspot.com/l/contacts/lists) that includes contacts that have filled out any event form
-9. Create a "My Events" page in your portal that:
-   - Has the slug `/my-events/`
-   - Uses the `Events app` module in a page template and has the form you created in `6.` selected in the module fields.; the page shouldn't be dynamic
+9. Create a `my events` page in your portal that:
+   - Uses the `Events app` module in a page template and has the form you created in `6.` selected in the module fields. Under the `my events` field, select the page you're currently editing.
+   - The page shouldn't be dynamic.
    - Under "Control audience access for page", select "Private - Registration required" and select the list you made in the previous step
+10. In the `Events app` module on the 'events listing' page you created in step `7.`, select the `my events` page you just created.
+
+> _Note_: The `events` and the `my events` can be named, titled, and have any url you like, as long as they are selected in the appropriate page selector fields in both instances of the `Events app` module (on both `my events` and `events`).
+
+> _Note_: This app is configured to work on a single subdomain, so `my events` and `events` should be on the same subdomain
 
 #### Usage
 

--- a/src/App.js
+++ b/src/App.js
@@ -38,7 +38,7 @@ function App() {
             ) : (
               <a
                 style={{ textDecoration: 'none' }}
-                href={`/_hcms/mem/login?redirect_url=/${my_events_page}`}
+                href={`/_hcms/mem/login?redirect_url=/${myEventsPath}`}
               >
                 Log in to see your events
               </a>

--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ function App() {
   const [filteredEventProperties, setEventProperties] = useState([]);
   const events = state.events;
   const { my_events_page } = state.moduleData;
+  const myEventsPath = new URL(my_events_page).pathname;
 
   return (
     <ErrorBoundary>
@@ -31,7 +32,7 @@ function App() {
           )}
           <div className="my-events-link">
             {state.contact.isLoggedIn ? (
-              <Link to={my_events_page} className="event-button">
+              <Link to={myEventsPath} className="event-button">
                 View my Events
               </Link>
             ) : (

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ function App() {
   const [currentSearch, setCurrentSearch] = useState('');
   const [filteredEventProperties, setEventProperties] = useState([]);
   const events = state.events;
+  const { my_events_page } = state.moduleData;
 
   return (
     <ErrorBoundary>
@@ -30,13 +31,13 @@ function App() {
           )}
           <div className="my-events-link">
             {state.contact.isLoggedIn ? (
-              <Link to="/my-events" className="event-button">
+              <Link to={my_events_page} className="event-button">
                 View my Events
               </Link>
             ) : (
               <a
                 style={{ textDecoration: 'none' }}
-                href="/_hcms/mem/login?redirect_url=/my-events"
+                href={`/_hcms/mem/login?redirect_url=/${my_events_page}`}
               >
                 Log in to see your events
               </a>

--- a/src/RegisteredEventsPage.js
+++ b/src/RegisteredEventsPage.js
@@ -7,6 +7,7 @@ import { AppContext } from './AppContext';
 function RegisteredEventsPage() {
   const [state] = useContext(AppContext);
   const { my_events_page } = state.moduleData;
+  const myEventsPath = new URL(my_events_page).pathname;
 
   return (
     <ErrorBoundary>
@@ -22,7 +23,7 @@ function RegisteredEventsPage() {
             ) : (
               <div className="login-message">
                 You must{' '}
-                <a href={`/_hcms/mem/login?redirect_url=${my_events_page}`}>
+                <a href={`/_hcms/mem/login?redirect_url=${myEventsPath}`}>
                   log in
                 </a>{' '}
                 to continue.

--- a/src/RegisteredEventsPage.js
+++ b/src/RegisteredEventsPage.js
@@ -6,6 +6,7 @@ import { AppContext } from './AppContext';
 
 function RegisteredEventsPage() {
   const [state] = useContext(AppContext);
+  const { my_events_page } = state.moduleData;
 
   return (
     <ErrorBoundary>
@@ -21,8 +22,10 @@ function RegisteredEventsPage() {
             ) : (
               <div className="login-message">
                 You must{' '}
-                <a href="/_hcms/mem/login?redirect_url=/my-events">log in</a> to
-                continue.
+                <a href={`/_hcms/mem/login?redirect_url=${my_events_page}`}>
+                  log in
+                </a>{' '}
+                to continue.
               </div>
             )}
           </div>

--- a/src/UpcomingEvents.js
+++ b/src/UpcomingEvents.js
@@ -9,7 +9,7 @@ import './scss/upcoming-events.scss';
 
 function UpcomingEvents() {
   const [state] = useContext(AppContext);
-  const appRoot = state.moduleData.event_page;
+  const AppRoot = state.moduleData.event_page;
   const upcomingEvents = state.events.slice(0, 3);
   const eventsLoaded = state.eventsLoaded;
 
@@ -20,7 +20,7 @@ function UpcomingEvents() {
       ) : (
         upcomingEvents.map(function(obj, i) {
           return (
-            <a href={`${appRoot}/${obj.path}`} className="event-card__link">
+            <a href={`${AppRoot}/${obj.path}`} className="event-card__link">
               <EventCard key={i} row={obj} />
             </a>
           );

--- a/src/UpcomingEvents.js
+++ b/src/UpcomingEvents.js
@@ -9,7 +9,7 @@ import './scss/upcoming-events.scss';
 
 function UpcomingEvents() {
   const [state] = useContext(AppContext);
-  const AppRoot = state.moduleData.event_page;
+  const { events_root } = state.moduleData;
   const upcomingEvents = state.events.slice(0, 3);
   const eventsLoaded = state.eventsLoaded;
 
@@ -20,7 +20,7 @@ function UpcomingEvents() {
       ) : (
         upcomingEvents.map(function(obj, i) {
           return (
-            <a href={`${AppRoot}/${obj.path}`} className="event-card__link">
+            <a href={`${events_root}/${obj.path}`} className="event-card__link">
               <EventCard key={i} row={obj} />
             </a>
           );

--- a/src/UpcomingEvents.js
+++ b/src/UpcomingEvents.js
@@ -40,10 +40,11 @@ preRenderedDataNodes.forEach(({ dataset, textContent }) => {
   const root = document.getElementById(
     `upcoming-events__module--${dataset.moduleInstance}`,
   );
+  const __MODULE_DATA__ = JSON.parse(textContent);
   return ReactDOM.render(
     <AppProvider
       portalId={Number(dataset.portalId)}
-      moduleData={JSON.parse(textContent)}
+      moduleData={__MODULE_DATA__}
     >
       <UpcomingEvents />
     </AppProvider>,

--- a/src/UpcomingEvents.js
+++ b/src/UpcomingEvents.js
@@ -9,6 +9,7 @@ import './scss/upcoming-events.scss';
 
 function UpcomingEvents() {
   const [state] = useContext(AppContext);
+  const appRoot = state.moduleData.event_page;
   const upcomingEvents = state.events.slice(0, 3);
   const eventsLoaded = state.eventsLoaded;
 
@@ -19,7 +20,7 @@ function UpcomingEvents() {
       ) : (
         upcomingEvents.map(function(obj, i) {
           return (
-            <a href={`/events/${obj.path}`} className="event-card__link">
+            <a href={`${appRoot}/${obj.path}`} className="event-card__link">
               <EventCard key={i} row={obj} />
             </a>
           );
@@ -30,12 +31,22 @@ function UpcomingEvents() {
     <LoadingSpinner />
   );
 }
-const root = document.getElementById('upcoming-events__module');
-const portalId = Number(root.dataset.portalId);
 
-ReactDOM.render(
-  <AppProvider portalId={portalId}>
-    <UpcomingEvents />
-  </AppProvider>,
-  root,
+const preRenderedDataNodes = document.querySelectorAll(
+  '.upcoming-events > script[type="application/json"]',
 );
+
+preRenderedDataNodes.forEach(({ dataset, textContent }) => {
+  const root = document.getElementById(
+    `upcoming-events__module--${dataset.moduleInstance}`,
+  );
+  return ReactDOM.render(
+    <AppProvider
+      portalId={Number(dataset.portalId)}
+      moduleData={JSON.parse(textContent)}
+    >
+      <UpcomingEvents />
+    </AppProvider>,
+    root,
+  );
+});

--- a/src/components/AppHero.js
+++ b/src/components/AppHero.js
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { AppContext } from '../AppContext.js';
+import { AppContext } from '../AppContext';
 import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';

--- a/src/components/AppHero.js
+++ b/src/components/AppHero.js
@@ -8,6 +8,7 @@ import './AppHero.scss';
 const AppHero = () => {
   const [state] = useContext(AppContext);
   const heroImgSrc = state.moduleData.hero_img.src;
+  const AppRoot = state.moduleData.event_page;
 
   return (
     <header
@@ -16,7 +17,7 @@ const AppHero = () => {
         backgroundImage: `url("${heroImgSrc}")`,
       }}
     >
-      <Link to={`/${state.moduleData.event_page}`} className="back-banner">
+      <Link to={AppRoot} className="back-banner">
         <FontAwesomeIcon icon={faChevronLeft} className="back-banner__icon" />
         Back to Events
       </Link>

--- a/src/components/AppHero.js
+++ b/src/components/AppHero.js
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, {useContext} from 'react';
+import {AppContext} from '../AppContext'
 import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 
 const AppHero = () => {
+  const [state] = useContext(AppContext);
   return (
     <header
       className="App-hero"
@@ -11,7 +13,7 @@ const AppHero = () => {
         backgroundImage: `url("{{ get_asset_url('./images/grayscale-mountain-banner.png') }}")`,
       }}
     >
-      <Link to="/events" className="back-banner">
+      <Link to={`/${state.moduleData.event_page}`} className="back-banner">
         <FontAwesomeIcon icon={faChevronLeft} className="back-banner__icon" />
         Back to Events
       </Link>

--- a/src/components/AppHero.js
+++ b/src/components/AppHero.js
@@ -7,17 +7,17 @@ import './AppHero.scss';
 
 const AppHero = () => {
   const [state] = useContext(AppContext);
-  const heroImgSrc = state.moduleData.hero_img.src;
-  const AppRoot = state.moduleData.event_page;
+  const { events_root, hero_img } = state.moduleData;
+  const eventsRootPath = new URL(events_root).pathname;
 
   return (
     <header
       className="App-hero"
       style={{
-        backgroundImage: `url("${heroImgSrc}")`,
+        backgroundImage: `url("${hero_img.src}")`,
       }}
     >
-      <Link to={AppRoot} className="back-banner">
+      <Link to={eventsRootPath} className="back-banner">
         <FontAwesomeIcon icon={faChevronLeft} className="back-banner__icon" />
         Back to Events
       </Link>

--- a/src/components/AppHero.js
+++ b/src/components/AppHero.js
@@ -1,5 +1,5 @@
-import React, {useContext} from 'react';
-import {AppContext} from '../AppContext'
+import React, { useContext } from 'react';
+import { AppContext } from '../AppContext';
 import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';

--- a/src/components/EventListings.js
+++ b/src/components/EventListings.js
@@ -11,7 +11,7 @@ import _lang from 'lodash/lang';
 const EventListings = ({ events, currentSearch, filteredEventProperties }) => {
   const [state] = useContext(AppContext);
   const { events_root } = state.moduleData;
-  const eventsRootPath = new URL(events_root).pathname
+  const eventsRootPath = new URL(events_root).pathname;
   let filteredEvents = events;
 
   if (currentSearch) {

--- a/src/components/EventListings.js
+++ b/src/components/EventListings.js
@@ -10,6 +10,7 @@ import _lang from 'lodash/lang';
 
 const EventListings = ({ events, currentSearch, filteredEventProperties }) => {
   const [state] = useContext(AppContext);
+  const AppRoot = state.moduleData.event_page;
   let filteredEvents = events;
 
   if (currentSearch) {
@@ -42,7 +43,7 @@ const EventListings = ({ events, currentSearch, filteredEventProperties }) => {
         filteredEvents.map(function(obj, i) {
           return (
             <Link
-              to={`${state.moduleData.event_page}/${obj.path}`}
+              to={`${AppRoot}/${obj.path}`}
               className="event-card__link"
             >
               <EventCard key={i} row={obj} />

--- a/src/components/EventListings.js
+++ b/src/components/EventListings.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, {useContext} from 'react';
+import {AppContext} from '../AppContext';
 import { Link } from 'react-router-dom';
 import EventCard from './EventCard';
 import './EventListings.scss';
@@ -8,6 +9,7 @@ import _collection from 'lodash/collection';
 import _lang from 'lodash/lang';
 
 const EventListings = ({ events, currentSearch, filteredEventProperties }) => {
+  const [state] = useContext(AppContext);
   let filteredEvents = events;
 
   if (currentSearch) {
@@ -39,7 +41,7 @@ const EventListings = ({ events, currentSearch, filteredEventProperties }) => {
       ) : (
         filteredEvents.map(function(obj, i) {
           return (
-            <Link to={`/events/${obj.path}`} className="event-card__link">
+            <Link to={`${state.moduleData.event_page}/${obj.path}`} className="event-card__link">
               <EventCard key={i} row={obj} />
             </Link>
           );

--- a/src/components/EventListings.js
+++ b/src/components/EventListings.js
@@ -1,5 +1,5 @@
-import React, {useContext} from 'react';
-import {AppContext} from '../AppContext';
+import React, { useContext } from 'react';
+import { AppContext } from '../AppContext';
 import { Link } from 'react-router-dom';
 import EventCard from './EventCard';
 import './EventListings.scss';
@@ -41,7 +41,10 @@ const EventListings = ({ events, currentSearch, filteredEventProperties }) => {
       ) : (
         filteredEvents.map(function(obj, i) {
           return (
-            <Link to={`${state.moduleData.event_page}/${obj.path}`} className="event-card__link">
+            <Link
+              to={`${state.moduleData.event_page}/${obj.path}`}
+              className="event-card__link"
+            >
               <EventCard key={i} row={obj} />
             </Link>
           );

--- a/src/components/EventListings.js
+++ b/src/components/EventListings.js
@@ -10,7 +10,8 @@ import _lang from 'lodash/lang';
 
 const EventListings = ({ events, currentSearch, filteredEventProperties }) => {
   const [state] = useContext(AppContext);
-  const AppRoot = state.moduleData.event_page;
+  const { events_root } = state.moduleData;
+  const eventsRootPath = new URL(events_root).pathname
   let filteredEvents = events;
 
   if (currentSearch) {
@@ -43,7 +44,7 @@ const EventListings = ({ events, currentSearch, filteredEventProperties }) => {
         filteredEvents.map(function(obj, i) {
           return (
             <Link
-              to={`${AppRoot}/${obj.path}`}
+              to={`${eventsRootPath}/${obj.path}`}
               className="event-card__link"
             >
               <EventCard key={i} row={obj} />

--- a/src/components/RegisteredEventListings.js
+++ b/src/components/RegisteredEventListings.js
@@ -37,7 +37,10 @@ function RegisteredEventListings() {
           {state.events.map(
             (event, i) =>
               registeredEventSlugs.indexOf(event.path) != -1 && (
-                <Link to={`${state.moduleData.event_page}/${event.path}`} className="event-card__link">
+                <Link
+                  to={`${state.moduleData.event_page}/${event.path}`}
+                  className="event-card__link"
+                >
                   <EventCard key={i} row={event} />
                 </Link>
               ),

--- a/src/components/RegisteredEventListings.js
+++ b/src/components/RegisteredEventListings.js
@@ -37,7 +37,7 @@ function RegisteredEventListings() {
           {state.events.map(
             (event, i) =>
               registeredEventSlugs.indexOf(event.path) != -1 && (
-                <Link to={`/events/${event.path}`} className="event-card__link">
+                <Link to={`${state.moduleData.event_page}/${event.path}`} className="event-card__link">
                   <EventCard key={i} row={event} />
                 </Link>
               ),

--- a/src/components/RegisteredEventListings.js
+++ b/src/components/RegisteredEventListings.js
@@ -10,6 +10,8 @@ function RegisteredEventListings() {
   const [registeredEventSlugsLoaded, setRegisteredEventSlugsLoaded] = useState(
     false,
   );
+  const { events_root } = state.moduleData;
+  const eventsRootPath = new URL(events_root).pathname;
 
   const getRegisteredEvents = async () => {
     // This function fetchs same-origin in order to pass cookies to the API and recieves a formSubmissions object
@@ -38,7 +40,7 @@ function RegisteredEventListings() {
             (event, i) =>
               registeredEventSlugs.indexOf(event.path) != -1 && (
                 <Link
-                  to={`${state.moduleData.event_page}/${event.path}`}
+                  to={`${eventsRootPath}/${event.path}`}
                   className="event-card__link"
                 >
                   <EventCard key={i} row={event} />

--- a/src/components/RegistrationConfirmation.js
+++ b/src/components/RegistrationConfirmation.js
@@ -11,6 +11,7 @@ const RegistrationConfirmation = ({ formData }) => {
   const { slug } = useParams();
   const eventData = state.events;
   const currentEvent = eventData.find(event => event.path === slug);
+  const { my_events_page } = state.moduleData;
 
   return (
     <div className="registration-confirmation">
@@ -38,7 +39,7 @@ const RegistrationConfirmation = ({ formData }) => {
       <p className="registration-confirmation__info">{formData.email}</p>
       <div className="event-details__registration--info">
         {state.contact.isLoggedIn ? (
-          <Link to="/my-events" className="event-button">
+          <Link to={my_events_page} className="event-button">
             View All My Events
           </Link>
         ) : (

--- a/src/components/RegistrationConfirmation.js
+++ b/src/components/RegistrationConfirmation.js
@@ -12,6 +12,7 @@ const RegistrationConfirmation = ({ formData }) => {
   const eventData = state.events;
   const currentEvent = eventData.find(event => event.path === slug);
   const { my_events_page } = state.moduleData;
+  const myEventsPath = new URL(my_events_page).pathname;
 
   return (
     <div className="registration-confirmation">
@@ -39,7 +40,7 @@ const RegistrationConfirmation = ({ formData }) => {
       <p className="registration-confirmation__info">{formData.email}</p>
       <div className="event-details__registration--info">
         {state.contact.isLoggedIn ? (
-          <Link to={my_events_page} className="event-button">
+          <Link to={myEventsPath} className="event-button">
             View All My Events
           </Link>
         ) : (

--- a/src/index.js
+++ b/src/index.js
@@ -23,13 +23,13 @@ const preRenderedDataNodes = document.querySelectorAll(
 );
 
 preRenderedDataNodes.forEach(({ dataset, textContent }) => {
+  console.log(textContent);
   const root = document.getElementById(
     `event-registration__module--${dataset.moduleInstance}`,
   );
   const __MODULE_DATA__ = JSON.parse(textContent);
-  const AppRoot = `${__MODULE_DATA__.event_page}`;
-  const { my_events_page } = __MODULE_DATA__;
-  ReactDOM.render(
+  const { events_root, my_events_page } = __MODULE_DATA__;
+    ReactDOM.render(
     <BrowserRouter>
       <ScrollToTop />
       <AppProvider
@@ -37,9 +37,20 @@ preRenderedDataNodes.forEach(({ dataset, textContent }) => {
         moduleData={__MODULE_DATA__}
       >
         <Switch>
-          <Route exact path={AppRoot} component={App} />
-          <Route path={`${AppRoot}/:slug`} component={EventDetailPage} />
-          <Route exact path={my_events_page} component={RegisteredEventsPage} />
+        <Route
+            exact
+            path={new URL(my_events_page).pathname}
+            component={RegisteredEventsPage}
+          />
+          <Route
+            exact
+            path={new URL(events_root).pathname}
+            component={App}
+          />
+          <Route
+            path={`${new URL(events_root).pathname}/:slug`}
+            component={EventDetailPage}
+          />
           <Route component={App} />
         </Switch>
       </AppProvider>

--- a/src/index.js
+++ b/src/index.js
@@ -17,23 +17,31 @@ const ScrollToTop = () => {
 
   return null;
 };
-const __MODULE_DATA__ = JSON.parse(
-  document.querySelector('[type="application/json"]').textContent,
+
+const preRenderedDataNodes = document.querySelectorAll(
+  '.event-registration > script[type="application/json"]',
 );
 
-const root = document.getElementById('root');
-const portalId = Number(root.dataset.portalId);
-ReactDOM.render(
-  <BrowserRouter>
-    <ScrollToTop />
-    <AppProvider portalId={portalId} moduleData={__MODULE_DATA__}>
-      <Switch>
-        <Route exact path="/events" component={App} />
-        <Route path="/events/:slug" component={EventDetailPage} />
-        <Route exact path="/my-events" component={RegisteredEventsPage} />
-        <Route component={App} />
-      </Switch>
-    </AppProvider>
-  </BrowserRouter>,
-  root,
-);
+preRenderedDataNodes.forEach(({ dataset, textContent }) => {
+  const root = document.getElementById(
+    `event-registration__module--${dataset.moduleInstance}`,
+  );
+  const __MODULE_DATA__ = JSON.parse(textContent);
+  ReactDOM.render(
+    <BrowserRouter>
+      <ScrollToTop />
+      <AppProvider
+        portalId={Number(dataset.portalId)}
+        moduleData={__MODULE_DATA__}
+      >
+        <Switch>
+          <Route exact path="/events" component={App} />
+          <Route path="/events/:slug" component={EventDetailPage} />
+          <Route exact path="/my-events" component={RegisteredEventsPage} />
+          <Route component={App} />
+        </Switch>
+      </AppProvider>
+    </BrowserRouter>,
+    root,
+  );
+});

--- a/src/index.js
+++ b/src/index.js
@@ -23,13 +23,12 @@ const preRenderedDataNodes = document.querySelectorAll(
 );
 
 preRenderedDataNodes.forEach(({ dataset, textContent }) => {
-  console.log(textContent);
   const root = document.getElementById(
     `event-registration__module--${dataset.moduleInstance}`,
   );
   const __MODULE_DATA__ = JSON.parse(textContent);
   const { events_root, my_events_page } = __MODULE_DATA__;
-    ReactDOM.render(
+  ReactDOM.render(
     <BrowserRouter>
       <ScrollToTop />
       <AppProvider
@@ -37,16 +36,12 @@ preRenderedDataNodes.forEach(({ dataset, textContent }) => {
         moduleData={__MODULE_DATA__}
       >
         <Switch>
-        <Route
+          <Route
             exact
             path={new URL(my_events_page).pathname}
             component={RegisteredEventsPage}
           />
-          <Route
-            exact
-            path={new URL(events_root).pathname}
-            component={App}
-          />
+          <Route exact path={new URL(events_root).pathname} component={App} />
           <Route
             path={`${new URL(events_root).pathname}/:slug`}
             component={EventDetailPage}

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ preRenderedDataNodes.forEach(({ dataset, textContent }) => {
     `event-registration__module--${dataset.moduleInstance}`,
   );
   const __MODULE_DATA__ = JSON.parse(textContent);
+  const appBase = `${__MODULE_DATA__.event_page}`;
   ReactDOM.render(
     <BrowserRouter>
       <ScrollToTop />
@@ -35,8 +36,8 @@ preRenderedDataNodes.forEach(({ dataset, textContent }) => {
         moduleData={__MODULE_DATA__}
       >
         <Switch>
-          <Route exact path="/events" component={App} />
-          <Route path="/events/:slug" component={EventDetailPage} />
+          <Route exact path={appBase} component={App} />
+          <Route path={`/${appBase}/:slug`} component={EventDetailPage} />
           <Route exact path="/my-events" component={RegisteredEventsPage} />
           <Route component={App} />
         </Switch>

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,8 @@ preRenderedDataNodes.forEach(({ dataset, textContent }) => {
     `event-registration__module--${dataset.moduleInstance}`,
   );
   const __MODULE_DATA__ = JSON.parse(textContent);
-  const appBase = `${__MODULE_DATA__.event_page}`;
+  const AppRoot = `${__MODULE_DATA__.event_page}`;
+  const { my_events_page } = __MODULE_DATA__;
   ReactDOM.render(
     <BrowserRouter>
       <ScrollToTop />
@@ -36,9 +37,9 @@ preRenderedDataNodes.forEach(({ dataset, textContent }) => {
         moduleData={__MODULE_DATA__}
       >
         <Switch>
-          <Route exact path={appBase} component={App} />
-          <Route path={`/${appBase}/:slug`} component={EventDetailPage} />
-          <Route exact path="/my-events" component={RegisteredEventsPage} />
+          <Route exact path={AppRoot} component={App} />
+          <Route path={`${AppRoot}/:slug`} component={EventDetailPage} />
+          <Route exact path={my_events_page} component={RegisteredEventsPage} />
           <Route component={App} />
         </Switch>
       </AppProvider>

--- a/src/modules/events-app.module/fields.json
+++ b/src/modules/events-app.module/fields.json
@@ -214,5 +214,13 @@
         "background_color_form": {}
       }
     }
+  },
+  {
+    "default": null,
+    "label": "My Events page",
+    "locked": false,
+    "name": "my_events_page",
+    "required": true,
+    "type": "page"
   }
 ]

--- a/src/modules/events-app.module/fields.json
+++ b/src/modules/events-app.module/fields.json
@@ -228,6 +228,14 @@
   },
   {
     "default": null,
+    "label": "Events page",
+    "locked": false,
+    "name": "events_root",
+    "required": true,
+    "type": "page"
+  },
+  {
+    "default": null,
     "label": "My Events page",
     "locked": false,
     "name": "my_events_page",

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -15,7 +15,8 @@
     data-module-instance="{{ name }}"
     data-portal-id="{{ portal_id }}">
     {%- do module.update({
-      'event_page': slug
+      'event_page': slug,
+      'my_event_page': content_by_id(module.my_event_page).absoluteUrl
     })-%}
     {{ module|tojson }}
   </script>

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -1,6 +1,3 @@
-  {% require_js %}
-
-  {% end_require_js %}
 {{ require_css(get_asset_url('../../event-registration.css')) }}
 {{ require_js(get_asset_url('../../vendor.js'), 'footer') }}
 {{ require_js(get_asset_url('../../event-registration.js'), 'footer') }}

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -14,11 +14,12 @@
   <script type="application/json"
     data-module-instance="{{ name }}"
     data-portal-id="{{ portal_id }}">
-    {%- do module.update({
+    {%- set moduleData = module -%}
+    {%- do moduleData.update({
       'event_page': slug,
       'my_event_page': content_by_id(module.my_event_page).absoluteUrl
     })-%}
-    {{ module|tojson }}
+    {{ moduleData|tojson }}
   </script>
   {% require_css %}
   <style>

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -7,11 +7,6 @@
 {{ require_js(get_asset_url('../../vendor.js'), 'footer') }}
 {{ require_js(get_asset_url('../../event-registration.js'), 'footer') }}
 
-{% set IMAGES = {
-  'close': get_asset_url('../../images/close.png'),
-  'map': get_asset_url('../../images/map.png'),
-  'city': get_asset_url('../../images/city.jpg'), } %}
-
 {%- macro outputColorIfSet(property, color, css_selector) -%}
   {%- if color.color -%}
     #hs_cos_wrapper_{{ name }} {{css_selector}} {

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -1,7 +1,5 @@
   {% require_js %}
-  <script type="application/json" data-module-instance="{{ name }}">
-    {{ module|tojson }}
-  </script>
+
   {% end_require_js %}
 {{ require_css(get_asset_url('../../event-registration.css')) }}
 {{ require_js(get_asset_url('../../vendor.js'), 'footer') }}
@@ -16,6 +14,14 @@
 {%- endmacro -%}
 
 <div class="event-registration">
+  <script type="application/json"
+    data-module-instance="{{ name }}"
+    data-portal-id="{{ portal_id }}">
+    {%- do module.update({
+      'event_page': slug
+    })-%}
+    {{ module|tojson }}
+  </script>
   {% require_css %}
   <style>
     {% if module.customize_styles %}
@@ -38,5 +44,5 @@
   </style>
   {% end_require_css %}
   <noscript>You need to enable JavaScript to run this app.</noscript>
-  <div id="root" data-portal-id="{{ portal_id }}"></div>
+  <div id="event-registration__module--{{ name }}"></div>
 </div>

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -16,8 +16,8 @@
     data-portal-id="{{ portal_id }}">
     {%- set moduleData = module -%}
     {%- do moduleData.update({
-      'event_page': slug,
-      'my_event_page': content_by_id(module.my_event_page).absoluteUrl
+      'events_root': content_by_id(moduleData.events_root).absoluteUrl,
+      'my_events_page': content_by_id(moduleData.my_events_page).absoluteUrl
     })-%}
     {{ moduleData|tojson }}
   </script>

--- a/src/modules/upcoming-events.module/fields.json
+++ b/src/modules/upcoming-events.module/fields.json
@@ -48,5 +48,13 @@
     "required": false,
     "locked": false,
     "default": {}
+  },
+  {
+    "default": null,
+    "label": "Event page",
+    "locked": false,
+    "name": "event_page",
+    "required": true,
+    "type": "page"
   }
 ]

--- a/src/modules/upcoming-events.module/fields.json
+++ b/src/modules/upcoming-events.module/fields.json
@@ -53,7 +53,7 @@
     "default": null,
     "label": "Event page",
     "locked": false,
-    "name": "event_page",
+    "name": "events_root",
     "required": true,
     "type": "page"
   }

--- a/src/modules/upcoming-events.module/module.html
+++ b/src/modules/upcoming-events.module/module.html
@@ -11,6 +11,14 @@
 {%- endmacro -%}
 
 <div class="upcoming-events">
+  <script type="application/json"
+    data-module-instance="{{ name }}"
+    data-portal-id="{{ portal_id }}">
+    {%- do module.update({
+      'event_page': content_by_id(module.event_page).absoluteUrl
+    })-%}
+    {{ module|tojson }}
+  </script>
   {% require_css %}
   <style>
     {{outputColorIfSet('background-color', module.background_color, '.upcoming-events')}}
@@ -21,5 +29,5 @@
   </style>
   {% end_require_css %}
   <h2 class="event-header">{{ module.heading }}</h2>
-  <div id="upcoming-events__module" data-portal-id="{{ portal_id }}"></div>
+  <div id="upcoming-events__module--{{ name }}"></div>
 </div>

--- a/src/modules/upcoming-events.module/module.html
+++ b/src/modules/upcoming-events.module/module.html
@@ -14,10 +14,11 @@
   <script type="application/json"
     data-module-instance="{{ name }}"
     data-portal-id="{{ portal_id }}">
-    {%- do module.update({
+    {%- set moduleData = module -%}
+    {%- do moduleData.update({
       'event_page': content_by_id(module.event_page).absoluteUrl
     })-%}
-    {{ module|tojson }}
+    {{ moduleData|tojson }}
   </script>
   {% require_css %}
   <style>

--- a/src/modules/upcoming-events.module/module.html
+++ b/src/modules/upcoming-events.module/module.html
@@ -16,7 +16,7 @@
     data-portal-id="{{ portal_id }}">
     {%- set moduleData = module -%}
     {%- do moduleData.update({
-      'event_page': content_by_id(module.event_page).absoluteUrl
+      'events_root': content_by_id(moduleData.events_root).absoluteUrl
     })-%}
     {{ moduleData|tojson }}
   </script>


### PR DESCRIPTION
Continuation of the work done by @anthmatic in #6 in the context of where we landed for https://github.com/HubSpot/cms-react-boilerplate
- Adds multiple instance support for both modules
- updates `{{ module }}` prior to sending to app to pre-evaluate any module data that requires extra HubL (like `content_by_id()`, `slug` -- I'm on the fence about this approach and could use some feedback)
- re-organizes the `module|tojson` pass in events app to remain consistent with the CMS React boilerplate

TODO:
- [x] Should `my-events` be made configurable from the events app module, too?
