### PR TITLE
Remove unavailable images from events module

### DIFF
--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -7,11 +7,6 @@
 {{ require_js(get_asset_url('../../vendor.js'), 'footer') }}
 {{ require_js(get_asset_url('../../event-registration.js'), 'footer') }}
 
-{% set IMAGES = {
-  'close': get_asset_url('../../images/close.png'),
-  'map': get_asset_url('../../images/map.png'),
-  'city': get_asset_url('../../images/city.jpg'), } %}
-
 {%- macro outputColorIfSet(property, color, css_selector) -%}
   {%- if color.color -%}
     #hs_cos_wrapper_{{ name }} {{css_selector}} {


### PR DESCRIPTION
Noticed the warning that the images were missing from within design manager. Not sure when they stopped being included/used.