### PR TITLE
Add customizable hero img

### DIFF
--- a/src/components/AppHero.js
+++ b/src/components/AppHero.js
@@ -3,6 +3,7 @@ import { AppContext } from '../AppContext.js';
 import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
+import './AppHero.scss';
 
 const AppHero = () => {
   const [state] = useContext(AppContext);

--- a/src/components/AppHero.js
+++ b/src/components/AppHero.js
@@ -1,14 +1,18 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import { AppContext } from '../AppContext.js';
 import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 
 const AppHero = () => {
+  const [state] = useContext(AppContext);
+  const heroImgSrc = state.moduleData.hero_img.src;
+
   return (
     <header
       className="App-hero"
       style={{
-        backgroundImage: `url("{{ get_asset_url('./images/grayscale-mountain-banner.png') }}")`,
+        backgroundImage: `url("${heroImgSrc}")`,
       }}
     >
       <Link to="/events" className="back-banner">

--- a/src/components/AppHero.scss
+++ b/src/components/AppHero.scss
@@ -1,0 +1,7 @@
+
+.App-hero {
+  background-position: center 75%;
+  height: 350px;
+  background-color: #eee;
+  padding-top: 230px;
+}

--- a/src/components/AppHero.scss
+++ b/src/components/AppHero.scss
@@ -1,4 +1,3 @@
-
 .App-hero {
   background-position: center 75%;
   background-repeat: no-repeat;

--- a/src/components/AppHero.scss
+++ b/src/components/AppHero.scss
@@ -1,6 +1,8 @@
 
 .App-hero {
   background-position: center 75%;
+  background-repeat: no-repeat;
+  background-size: cover;
   height: 350px;
   background-color: #eee;
   padding-top: 230px;

--- a/src/modules/events-app.module/fields.json
+++ b/src/modules/events-app.module/fields.json
@@ -5,13 +5,9 @@
     "id": "hero_img",
     "type": "image",
     "resizable": false,
-    "visibility": {
-      "hidden_subfields": {
-        "alt": true
-      }
-    },
     "default": {
-      "src": "https://designers.hubspot.com/hubfs/event-registration/grayscale-mountain-banner.png"
+      "src": "https://designers.hubspot.com/hubfs/event-registration/grayscale-mountain-banner.png",
+      "alt": null
     }
   },
   {

--- a/src/modules/events-app.module/fields.json
+++ b/src/modules/events-app.module/fields.json
@@ -1,5 +1,21 @@
 [
   {
+    "label": "Hero Banner Image",
+    "name": "hero_img",
+    "id": "hero_img",
+    "type": "image",
+    "visibility": {
+      "hidden_subfields": {
+        "alt": true,
+        "width": true,
+        "height": true
+      }
+    },
+    "default": {
+      "src": "https://designers.hubspot.com/hubfs/event-registration/grayscale-mountain-banner.png"
+    }
+  },
+  {
     "label": "Customize styles",
     "name": "customize_styles",
     "type": "boolean",

--- a/src/modules/events-app.module/fields.json
+++ b/src/modules/events-app.module/fields.json
@@ -4,11 +4,10 @@
     "name": "hero_img",
     "id": "hero_img",
     "type": "image",
+    "resizable": false,
     "visibility": {
       "hidden_subfields": {
-        "alt": true,
-        "width": true,
-        "height": true
+        "alt": true
       }
     },
     "default": {

--- a/src/scss/App.scss
+++ b/src/scss/App.scss
@@ -11,13 +11,6 @@
   flex-wrap: wrap;
 }
 
-.App-hero {
-  background-position: center 75%;
-  height: 350px;
-  background-color: #eee;
-  padding-top: 230px;
-}
-
 // Form styles
 .form-error {
   display: none;


### PR DESCRIPTION
Resolves #56 

TODO:
- [x] hiding `dimensions` and `alt` via `visibility.hidden_subfields` in  `src/modules/events-app.module/fields.json` isn't working as I'd expect. Will dig in further.
  - I was misremembering this feature-- `resizable: false` will hide height / width, and I don't think there's a way to hide the alt text subfield in the module form UI for image fields.