### PR TITLE
Add functionality to handle missing values in HubDB columns

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React, { useState, useContext } from 'react';
 import ErrorBoundary from './components/ErrorBoundary';
 import EventListings from './components/EventListings';
 import EventFilterBar from './components/EventFilterBar';
+import ErrorPageEditor from './components/ErrorPageEditor';
 import { Link } from 'react-router-dom';
 import { AppContext } from './AppContext';
 import './scss/App.scss';
@@ -15,6 +16,11 @@ function App() {
   return (
     <ErrorBoundary>
       <div className="App">
+        <ErrorPageEditor
+          events={events}
+          portalId={state.portalId}
+          tableId={state.tableId}
+        />
         <EventFilterBar
           filteredEventProperties={filteredEventProperties}
           setEventProperties={setEventProperties}

--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import dayjs from 'dayjs';
+import _object from 'lodash/object';
 
 const AppContext = React.createContext([{}, () => {}]);
 
@@ -23,6 +24,20 @@ const AppProvider = props => {
     return eventList.filter(e => dayjs(e.values.start).isAfter(currentDate));
   };
 
+  const setDefaultValues = eventList => {
+    let filteredEvents = filterPastEvents(eventList);
+    return filteredEvents.map(e => {
+      e.values = _object.defaults(e.values, {
+        name: 'Untitled event',
+        event_description: 'Missing event description',
+        event_capacity: 25,
+        registered_attendee_count: 0,
+        attendance_type: [{id: "1", name: "virtual", type: "option", order: 0}]
+      });
+      return e;
+    });
+  };
+
   const getEvents = async () => {
     let response = await fetch(
       `https://api.hubspot.com/cms/v3/hubdb/tables/events/rows?sort=start&portalId=${props.portalId}`,
@@ -30,7 +45,7 @@ const AppProvider = props => {
     response = await response.json();
     setState(state => ({
       ...state,
-      events: filterPastEvents(response.results),
+      events: setDefaultValues(response.results),
     }));
     setState(state => ({
       ...state,

--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -19,13 +19,17 @@ const AppProvider = props => {
     moduleData: props.moduleData,
   });
 
-  const filterPastEvents = eventList => {
+  const filterFutureEvents = eventList => {
     let currentDate = dayjs(new Date());
-    return eventList.filter(e => dayjs(e.values.start).isAfter(currentDate));
+    return eventList.filter(
+      e =>
+        undefined === e.values.start ||
+        dayjs(e.values.start).isAfter(currentDate),
+    );
   };
 
   const setDefaultValues = eventList => {
-    let filteredEvents = filterPastEvents(eventList);
+    let filteredEvents = filterFutureEvents(eventList);
     return filteredEvents.map(e => {
       e.values = _object.defaults(e.values, {
         name: 'Untitled event',
@@ -76,7 +80,12 @@ const AppProvider = props => {
       `https://api.hubspot.com/cms/v3/hubdb/tables/events?portalId=${props.portalId}`,
     );
     response = await response.json();
-    setState(state => ({ ...state, columns: response.columns }));
+    setState(state => ({
+      ...state,
+      columns: response.columns,
+      portalId: props.portalId,
+      tableId: response.id,
+    }));
   };
 
   useEffect(() => {

--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -32,7 +32,9 @@ const AppProvider = props => {
         event_description: 'Missing event description',
         event_capacity: 25,
         registered_attendee_count: 0,
-        attendance_type: [{id: "1", name: "virtual", type: "option", order: 0}]
+        attendance_type: [
+          { id: '1', name: 'virtual', type: 'option', order: 0 },
+        ],
       });
       return e;
     });

--- a/src/components/ErrorPageEditor.js
+++ b/src/components/ErrorPageEditor.js
@@ -1,29 +1,29 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+//This component will only render in the HubSpot page editor.
 
 const ErrorPageEditor = ({ events, portalId, tableId }) => {
   function renderErrors() {
-    if (events) {
-      if (
-        events.find(e => e.name === '' || e.path === '') &&
-        window.hsInEditor
-      ) {
-        return (
-          <>
-            <h1>
-              Warning: Event with ID{' '}
-              {events.find(e => e.name === '' || e.path === '').id} in the HubDb
-              table is missing a page title or page path.
-            </h1>
-            <h2>
-              To fix this,{' '}
-              <Link to={`//app.hubspot.com/hubdb/${portalId}/table/${tableId}`}>
-                edit the Events HubDB table
-              </Link>
-            </h2>
-          </>
-        );
-      }
+    if (
+      events &&
+      events.find(e => e.name === '' || e.path === '') &&
+      window.hsInEditor
+    ) {
+      return (
+        <>
+          <h1>
+            Warning: Event with ID{' '}
+            {events.find(e => e.name === '' || e.path === '').id} in the HubDb
+            table is missing a page title or page path.
+          </h1>
+          <h2>
+            To fix this,{' '}
+            <Link to={`//app.hubspot.com/hubdb/${portalId}/table/${tableId}`}>
+              edit the Events HubDB table
+            </Link>
+          </h2>
+        </>
+      );
     }
   }
 

--- a/src/components/ErrorPageEditor.js
+++ b/src/components/ErrorPageEditor.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const ErrorPageEditor = ({ events, portalId, tableId }) => {
+  function renderErrors() {
+    if (events) {
+      if (
+        events.find(e => e.name === '' || e.path === '') &&
+        window.hsInEditor
+      ) {
+        return (
+          <>
+            <h1>
+              Warning: Event with ID{' '}
+              {events.find(e => e.name === '' || e.path === '').id} in the HubDb
+              table is missing a page title or page path.
+            </h1>
+            <h2>
+              To fix this,{' '}
+              <Link to={`//app.hubspot.com/hubdb/${portalId}/table/${tableId}`}>
+                edit the Events HubDB table
+              </Link>
+            </h2>
+          </>
+        );
+      }
+    }
+  }
+
+  return <div> {renderErrors()} </div>;
+};
+
+export default ErrorPageEditor;

--- a/src/components/EventCard.js
+++ b/src/components/EventCard.js
@@ -41,10 +41,16 @@ const EventCard = ({ row }) => {
         <div className="event-card__column">
           <div className="event-card__date">
             <FontAwesomeIcon icon={faClock} className="location-icon" />
-            <div>
-              <div>{dayjs(row.values.start).format('dddd, MMMM D, YYYY')}</div>
-              <div>{dayjs(row.values.start).format('h:mm A')}</div>
-            </div>
+            {row.values.start ? (
+              <div>
+                <div>
+                  {dayjs(row.values.start).format('dddd, MMMM D, YYYY')}
+                </div>
+                <div>{dayjs(row.values.start).format('h:mm A')}</div>
+              </div>
+            ) : (
+              <div> Time to be determined</div>
+            )}
           </div>
           {checkAttendanceType('in-person') && row.values.location_address && (
             <div className="event-card__address">
@@ -55,11 +61,10 @@ const EventCard = ({ row }) => {
               <div>
                 <div> {row.values.location_address.split(',')[0]} </div>
                 <div>
-                  {' '}
                   {row.values.location_address
                     .split(',')
                     .slice(1, 3)
-                    .join(', ')}{' '}
+                    .join(', ')}
                 </div>
               </div>
             </div>

--- a/src/components/EventCard.js
+++ b/src/components/EventCard.js
@@ -16,9 +16,7 @@ const EventCard = ({ row }) => {
   const eventImage = featureImage ? featureImage.url : '';
 
   function checkAttendanceType(type) {
-    if (row.values.attendance_type) {
-      return row.values.attendance_type.some(o => o.name === type);
-    }
+    return row.values.attendance_type.some(o => o.name === type);
   }
 
   function renderAttendanceType() {
@@ -66,12 +64,10 @@ const EventCard = ({ row }) => {
               </div>
             </div>
           )}
-          {row.values.attendance_type && (
-            <div className="event-card__event-type">
-              <FontAwesomeIcon icon={faCalendarAlt} className="event-icon" />
-              <div>{renderAttendanceType()}</div>
-            </div>
-          )}
+          <div className="event-card__event-type">
+            <FontAwesomeIcon icon={faCalendarAlt} className="event-icon" />
+            <div>{renderAttendanceType()}</div>
+          </div>
           <div className="event-card__capacity">
             {row.values.limited_event_capacity === 1 && (
               <FontAwesomeIcon icon={faUsers} className="people-icon" />

--- a/src/components/EventDetails.js
+++ b/src/components/EventDetails.js
@@ -37,9 +37,7 @@ const EventDetails = () => {
     event && event.values.feature_image ? event.values.feature_image.url : '';
 
   function checkAttendanceType(type) {
-    if (event.values.attendance_type) {
-      return event.values.attendance_type.some(o => o.name === type);
-    }
+    return event.values.attendance_type.some(o => o.name === type);
   }
 
   function renderAttendanceType() {
@@ -68,17 +66,12 @@ const EventDetails = () => {
               }}
             ></div>
             <div className="event-details__table">
-              {event.values.attendance_type && (
-                <div className="column">
-                  <FontAwesomeIcon
-                    icon={faCalendarAlt}
-                    className="event-icon"
-                  />
-                  <div className="event-details__meta-copy">
-                    <p> {renderAttendanceType()} </p>
-                  </div>
+              <div className="column">
+                <FontAwesomeIcon icon={faCalendarAlt} className="event-icon" />
+                <div className="event-details__meta-copy">
+                  <p> {renderAttendanceType()} </p>
                 </div>
-              )}
+              </div>
               <div className="column">
                 <FontAwesomeIcon icon={faClock} className="time-icon" />
                 <div className="event-details__meta-copy">

--- a/src/components/EventDetails.js
+++ b/src/components/EventDetails.js
@@ -73,12 +73,22 @@ const EventDetails = () => {
                 </div>
               </div>
               <div className="column">
-                <FontAwesomeIcon icon={faClock} className="time-icon" />
+                {event.values.start && (
+                  <FontAwesomeIcon icon={faClock} className="time-icon" />
+                )}
                 <div className="event-details__meta-copy">
-                  <p> {dayjs(event.values.start).format('MMMM D, YYYY')} </p>
                   <p>
-                    From {dayjs(event.values.start).format('hh:mm A')} to{' '}
-                    {dayjs(event.values.end).format('hh:mm A')}
+                    {event.values.start && (
+                      <>{dayjs(event.values.start).format('MMMM D, YYYY')}</>
+                    )}
+                  </p>
+                  <p>
+                    {event.values.start && (
+                      <> {dayjs(event.values.start).format('hh:mm A')} </>
+                    )}
+                    {event.values.start && event.values.end && (
+                      <> to {dayjs(event.values.end).format('hh:mm A')} </>
+                    )}
                   </p>
                 </div>
               </div>
@@ -92,11 +102,10 @@ const EventDetails = () => {
                     <div className="event-details__meta-copy">
                       <p> {event.values.location_address.split(',')[0]} </p>
                       <p>
-                        {' '}
                         {event.values.location_address
                           .split(',')
                           .slice(1, 3)
-                          .join(', ')}{' '}
+                          .join(', ')}
                       </p>
                     </div>
                   </div>

--- a/src/event.functions/eventSignup.js
+++ b/src/event.functions/eventSignup.js
@@ -50,9 +50,12 @@ exports.main = ({ body, accountId }, sendResponse) => {
   };
 
   const incrementAttendeeCount = async id => {
-    const { registered_attendee_count } = await getRow(id);
+    let { registered_attendee_count } = await getRow(id);
+    if (registered_attendee_count == null) {
+      registered_attendee_count = 0;
+    }
 
-    if (registered_attendee_count == null || registered_attendee_count < 0) {
+    if (registered_attendee_count < 0) {
       sendResponse({
         statusCode: 500,
         body: { message: 'Invalid attendee count value' },


### PR DESCRIPTION
Fixes #84 

I have four main concerns at the moment: 

1) I've added a function in `AppContext.js` to filter events and to add default values, where values are missing. I've taken advantage of the lodash `defaults` method to do so, but I'm curious whether anyone else might have other ideas how to achieve this.

2) I have added default values for certain columns--do these defaults make sense to everyone?  

DEFAULTS SET: 
Name: 'Untitled event' 
Event Description: 'Missing event description'
Event Capacity: 25
Registered Eventee Count: 0
Attendance Type: Virtual 

3) Currently, if an event is missing the Page Title or Page Path columns, no warnings appear. Without the Page Path column in particular, the user cannot select the event card to navigate to the event details page without this value. I'm not quite sure the best way to deliver a warning to the user. I'd appreciate any feedback. 

4) I'd like to set default values for the Start and End columns, but I'm unsure what the best values would be. It seems unwise to choose an arbitrary time and date. Again, I'd appreciate any feedback. 

cc @gcorne @anthmatic @levinkeo 
