### PR TITLE
Refactor event signup function

### DIFF
--- a/src/event.functions/eventSignup.js
+++ b/src/event.functions/eventSignup.js
@@ -59,7 +59,7 @@ exports.main = ({ body, accountId }, sendResponse) => {
       registered_attendee_count = 0;
     }
 
-    if (event_capacity == null && limited_event_capacity) {
+    if (event_capacity == null && limited_event_capacity === 1) {
       event_capacity = 25;
     }
 
@@ -70,7 +70,10 @@ exports.main = ({ body, accountId }, sendResponse) => {
       });
     }
 
-    if (registered_attendee_count >= event_capacity && limited_event_capacity) {
+    if (
+      registered_attendee_count >= event_capacity &&
+      limited_event_capacity === 1
+    ) {
       sendResponse({
         statusCode: 403,
         body: { message: 'Event has reached capacity' },


### PR DESCRIPTION
Per our discussions on Slack, I've refactored the event signup function, so that we: 

1) check the draft HubDB table for the registered attendee count, and 
2) compare the registered attendee count with the event capacity (if there is one). 

Only after these two steps do we increment the attendee count and update the HubDB table. 
