### PR TITLE
Reorder and regroup module fields

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,7 @@ function App() {
   const [currentSearch, setCurrentSearch] = useState('');
   const [filteredEventProperties, setEventProperties] = useState([]);
   const events = state.events;
-  const { my_events_page } = state.moduleData;
+  const { my_events_page } = state.moduleData.page_roots;
   const myEventsPath = new URL(my_events_page).pathname;
 
   return (

--- a/src/RegisteredEventsPage.js
+++ b/src/RegisteredEventsPage.js
@@ -6,7 +6,7 @@ import { AppContext } from './AppContext';
 
 function RegisteredEventsPage() {
   const [state] = useContext(AppContext);
-  const { my_events_page } = state.moduleData;
+  const { my_events_page } = state.moduleData.page_roots;
   const myEventsPath = new URL(my_events_page).pathname;
 
   return (

--- a/src/components/AppHero.js
+++ b/src/components/AppHero.js
@@ -7,7 +7,8 @@ import './AppHero.scss';
 
 const AppHero = () => {
   const [state] = useContext(AppContext);
-  const { events_root, hero_img } = state.moduleData;
+  const { hero_img } = state.moduleData.hero_image_group;
+  const { events_root } = state.moduleData.page_roots;
   const eventsRootPath = new URL(events_root).pathname;
 
   return (

--- a/src/components/EventListings.js
+++ b/src/components/EventListings.js
@@ -10,7 +10,7 @@ import _lang from 'lodash/lang';
 
 const EventListings = ({ events, currentSearch, filteredEventProperties }) => {
   const [state] = useContext(AppContext);
-  const { events_root } = state.moduleData;
+  const { events_root } = state.moduleData.page_roots;
   const eventsRootPath = new URL(events_root).pathname;
   let filteredEvents = events;
 

--- a/src/components/RegisteredEventListings.js
+++ b/src/components/RegisteredEventListings.js
@@ -10,7 +10,7 @@ function RegisteredEventListings() {
   const [registeredEventSlugsLoaded, setRegisteredEventSlugsLoaded] = useState(
     false,
   );
-  const { events_root } = state.moduleData;
+  const { events_root } = state.moduleData.page_roots;
   const eventsRootPath = new URL(events_root).pathname;
 
   const getRegisteredEvents = async () => {

--- a/src/components/RegistrationConfirmation.js
+++ b/src/components/RegistrationConfirmation.js
@@ -11,7 +11,7 @@ const RegistrationConfirmation = ({ formData }) => {
   const { slug } = useParams();
   const eventData = state.events;
   const currentEvent = eventData.find(event => event.path === slug);
-  const { my_events_page } = state.moduleData;
+  const { my_events_page } = state.moduleData.page_roots;
   const myEventsPath = new URL(my_events_page).pathname;
 
   return (

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ preRenderedDataNodes.forEach(({ dataset, textContent }) => {
     `event-registration__module--${dataset.moduleInstance}`,
   );
   const __MODULE_DATA__ = JSON.parse(textContent);
-  const { events_root, my_events_page } = __MODULE_DATA__;
+  const { events_root, my_events_page } = __MODULE_DATA__.page_roots;
   ReactDOM.render(
     <BrowserRouter>
       <ScrollToTop />

--- a/src/modules/events-app.module/fields.json
+++ b/src/modules/events-app.module/fields.json
@@ -25,6 +25,53 @@
     "type": "group"
   },
   {
+    "label": "Page",
+    "name": "page_roots",
+    "required": true,
+    "locked": false,
+    "children": [
+      {
+        "default": null,
+        "label": "Events page",
+        "locked": false,
+        "name": "events_root",
+        "required": true,
+        "type": "page"
+      },
+      {
+        "default": null,
+        "label": "My Events page",
+        "locked": false,
+        "name": "my_events_page",
+        "required": true,
+        "type": "page"
+      }
+    ],
+    "tab": "CONTENT",
+    "type": "group"
+  },
+  {
+    "label": "Hero Image Banner",
+    "name": "hero_image_group",
+    "required": false,
+    "locked": false,
+    "children": [
+      {
+        "label": "Hero Banner Image",
+        "name": "hero_img",
+        "id": "hero_img",
+        "type": "image",
+        "resizable": false,
+        "default": {
+          "src": "https://designers.hubspot.com/hubfs/event-registration/grayscale-mountain-banner.png",
+          "alt": null
+        }
+      }
+    ],
+    "tab": "CONTENT",
+    "type": "group"
+  },
+  {
     "label": "Customize Styles",
     "name": "customize_styles",
     "type": "boolean",
@@ -89,32 +136,5 @@
     ],
     "tab": "CONTENT",
     "type": "group"
-  },
-  {
-    "label": "Hero Banner Image",
-    "name": "hero_img",
-    "id": "hero_img",
-    "type": "image",
-    "resizable": false,
-    "default": {
-      "src": "https://designers.hubspot.com/hubfs/event-registration/grayscale-mountain-banner.png",
-      "alt": null
-    }
-  },
-  {
-    "default": null,
-    "label": "Events page",
-    "locked": false,
-    "name": "events_root",
-    "required": true,
-    "type": "page"
-  },
-  {
-    "default": null,
-    "label": "My Events page",
-    "locked": false,
-    "name": "my_events_page",
-    "required": true,
-    "type": "page"
   }
 ]

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -15,10 +15,9 @@
     data-module-instance="{{ name }}"
     data-portal-id="{{ portal_id }}">
     {%- set moduleData = module -%}
-    {%- do moduleData.update({
+    {%- do moduleData.page_roots.update({
       'events_root': content_by_id(moduleData.page_roots.events_root).absoluteUrl,
-      'my_events_page': content_by_id(moduleData.page_roots.my_events_page).absoluteUrl,
-      'hero_img': moduleData.hero_image_group.hero_img
+      'my_events_page': content_by_id(moduleData.page_roots.my_events_page).absoluteUrl
     })-%}
     {{ moduleData|tojson }}
   </script>

--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -16,8 +16,9 @@
     data-portal-id="{{ portal_id }}">
     {%- set moduleData = module -%}
     {%- do moduleData.update({
-      'events_root': content_by_id(moduleData.events_root).absoluteUrl,
-      'my_events_page': content_by_id(moduleData.my_events_page).absoluteUrl
+      'events_root': content_by_id(moduleData.page_roots.events_root).absoluteUrl,
+      'my_events_page': content_by_id(moduleData.page_roots.my_events_page).absoluteUrl,
+      'hero_img': moduleData.hero_image_group.hero_img
     })-%}
     {{ moduleData|tojson }}
   </script>

--- a/src/scss/upcoming-events.scss
+++ b/src/scss/upcoming-events.scss
@@ -34,9 +34,10 @@
   text-align: center;
 }
 
-.time-icon,
-.location-icon,
-.people-icon {
+.event-card__column .event-icon,
+.event-card__column .location-icon,
+.event-card__column .people-icon,
+.event-card__column .time-icon {
   height: 25px;
   width: 25px;
   margin-right: 10px;


### PR DESCRIPTION
Since incorporating my and @levinkeo's changes to the module fields, I thought that the fields looked a bit disorganized while working in the page editor. 

I reordered and regrouped the different field groups for a (hopefully) more seamless editing experience. 

cc @achong07, @levinkeo (you might want to take a look to ensure that I've updated `moduleData` correctly in the `module.html` file). 