### PR TITLE
Update Upcoming Events module with color schemes

### DIFF
--- a/src/modules/events-app.module/module.html
+++ b/src/modules/events-app.module/module.html
@@ -23,7 +23,6 @@
   </script>
   {% require_css %}
   <style>
-    {{module.colors.dark_color}}
     {% if module.customize_styles and module.colors.color_schemes %}
       {% if module.colors.dark_color.color != null and module.colors.light_color.color != null and module.colors.link_color.color != null %}
         {% if module.colors.color_schemes == 'dark_theme' %}

--- a/src/modules/upcoming-events.module/fields.json
+++ b/src/modules/upcoming-events.module/fields.json
@@ -1,60 +1,68 @@
 [
   {
-    "label": "Heading",
-    "name": "heading",
-    "type": "text",
-    "required": false,
-    "locked": false,
-    "allow_new_line": false,
-    "show_emoji_picker": true,
-    "default": "Upcoming Events"
-  },
-  {
-    "label": "Background color",
-    "name": "background_color",
-    "type": "color",
-    "required": false,
-    "locked": false,
-    "default": {}
-  },
-  {
-    "label": "Event card color",
-    "name": "event_card_color",
-    "type": "color",
-    "required": false,
-    "locked": false,
-    "default": {}
-  },
-  {
-    "label": "Text color",
-    "name": "text_color",
-    "type": "color",
-    "required": false,
-    "locked": false,
-    "default": {}
-  },
-  {
-    "label": "Title color",
-    "name": "title_color",
-    "type": "color",
-    "required": false,
-    "locked": false,
-    "default": {}
-  },
-  {
-    "label": "Event title color",
-    "name": "event_title_color",
-    "type": "color",
-    "required": false,
-    "locked": false,
-    "default": {}
-  },
-  {
     "default": null,
     "label": "Event page",
     "locked": false,
     "name": "events_root",
     "required": true,
     "type": "page"
+  },
+  {
+    "label": "Customize Styles",
+    "name": "customize_styles",
+    "type": "boolean",
+    "required": false,
+    "locked": false,
+    "default": false
+  },
+  {
+    "label": "Colors",
+    "name": "colors",
+    "required": false,
+    "locked": false,
+    "visibility": {
+      "controlling_field": "customize_styles",
+      "controlling_value_regex": "true",
+      "operator": "EQUAL"
+    },
+    "children": [
+      {
+        "label": "Light Color",
+        "name": "light_color",
+        "type": "color",
+        "required": false,
+        "locked": false,
+        "default": {}
+      },
+      {
+        "label": "Dark Color",
+        "name": "dark_color",
+        "type": "color",
+        "required": false,
+        "locked": false,
+        "default": {}
+      },
+      {
+        "label": "Color Schemes",
+        "name": "color_schemes",
+        "required": false,
+        "locked": false,
+        "visibility": {
+          "controlling_field": "customize_styles",
+          "controlling_value_regex": "true",
+          "operator": "EQUAL"
+        },
+        "display": "select",
+        "placeholder": "Choose a theme",
+        "choices": [
+          ["light_theme", "Light theme"],
+          ["dark_theme", "Dark theme"]
+        ],
+        "type": "choice",
+        "default": null
+      }
+    ],
+    "tab": "CONTENT",
+    "type": "group"
   }
 ]

--- a/src/modules/upcoming-events.module/module.html
+++ b/src/modules/upcoming-events.module/module.html
@@ -22,11 +22,23 @@
   </script>
   {% require_css %}
   <style>
-    {{outputColorIfSet('background-color', module.background_color, '.upcoming-events')}}
-    {{outputColorIfSet('color', module.text_color, '.upcoming-events')}}
-    {{outputColorIfSet('background-color', module.event_card_color, '.event-card')}}
-    {{outputColorIfSet('color', module.title_color, '.event-header')}}
-    {{outputColorIfSet('color', module.event_title_color, '.event-card__title')}}
+    {% if module.customize_styles and module.colors.color_schemes %}
+      {% if module.colors.dark_color.color != null and module.colors.light_color.color != null %}
+        {% if module.colors.color_schemes == 'dark_theme' %}
+          {{outputColorIfSet('background-color', module.colors.dark_color, '.event-listings--upcoming .event-card')}}
+
+          {{outputColorIfSet('color', module.colors.light_color, '.event-listings--upcoming .event-card')}}
+          {{outputColorIfSet('color', module.colors.light_color, '.event-listings--upcoming .event-card .event-card__title')}}
+        {% endif %}
+
+        {% if module.colors.color_schemes == 'light_theme' %}
+          {{outputColorIfSet('background-color', module.colors.light_color, '.event-listings--upcoming .event-card')}}
+
+          {{outputColorIfSet('color', module.colors.dark_color, '.event-listings--upcoming .event-card')}}
+          {{outputColorIfSet('color', module.colors.dark_color, '.event-listings--upcoming .event-card .event-card__title')}}
+        {% endif %}
+      {% endif %}
+    {% endif %}
   </style>
   {% end_require_css %}
   <h2 class="event-header">{{ module.heading }}</h2>


### PR DESCRIPTION
While I was reviewing the app, I noticed that we hadn't updated the module fields for the Upcoming Events module in quite some time. 

I've updated the color fields in the Upcoming Events module to mirror those in the Events app module. There is a Customize Style toggle button which controls the Colors field group. The Colors field group contains a "Light color" color field, a "Dark color" color field, and a Colors scheme dropdown menu. I've omitted the "Link color" color field, because the Upcoming Events module has no links. 