### PR TITLE
Relabel Hero Banner group

### DIFF
--- a/src/modules/events-app.module/fields.json
+++ b/src/modules/events-app.module/fields.json
@@ -51,7 +51,7 @@
     "type": "group"
   },
   {
-    "label": "Hero Image Banner",
+    "label": "Hero Banner",
     "name": "hero_image_group",
     "required": false,
     "locked": false,


### PR DESCRIPTION
I've relabeled one of the Events app field groups from 'Hero Image Banner' to 'Hero Banner.'