### PR TITLE
Bump node version to 14

### DIFF
--- a/src/event.functions/serverless.json
+++ b/src/event.functions/serverless.json
@@ -1,5 +1,5 @@
 {
-  "runtime": "nodejs12.x",
+  "runtime": "nodejs14.x",
   "version": "1.0",
   "secrets": ["APIKEY"],
   "endpoints": {


### PR DESCRIPTION
Bump default node version now that CMS serverless functions support this runtime.